### PR TITLE
container: keep track of generated containers.

### DIFF
--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -658,6 +658,12 @@ CFG["container"] = {
     "shell": {
         "default": "/bin/bash",
         "desc": "Command string that should be used as shell command."
+    },
+    "known" : {
+        "default": [],
+        "desc": "List of known containers. Format: "
+                "[{ 'path': <path>,"
+                "   'hash': <hash> }]"
     }
 }
 
@@ -705,6 +711,7 @@ def __init_config(cfg):
 
     if config_path:
         cfg.load(config_path)
+        cfg["config_file"] = os.path.abspath(config_path)
         logging.debug("Configuration loaded from {0}".format(os.path.abspath(
             config_path)))
     cfg.init_from_env()

--- a/benchbuild/utils/downloader.py
+++ b/benchbuild/utils/downloader.py
@@ -79,10 +79,12 @@ def update_hash(src, root):
     from os import path
 
     hash_file = path.join(root, src + ".hash")
+    new_hash = 0
     with open(hash_file, 'w') as h_file:
         src_path = path.join(root, src)
         new_hash = get_hash_of_dirs(src_path)
         h_file.write(str(new_hash))
+    return new_hash
 
 
 def Copy(From, To):


### PR DESCRIPTION
After we create a new container, we store the path and the hash of the
packed container in the user's config file.
The command: 'container list' prints all known containers.

Future commits will expand on this feature in 2 ways:
 * Select containers to run/unpack by their hash.
 * Migrate towards default container usage in benchbuild.