### PR TITLE
plumbum.cmd to benchbuild.utils.cmd redirection

### DIFF
--- a/benchbuild/build.py
+++ b/benchbuild/build.py
@@ -8,7 +8,7 @@ single image.
 """
 import os
 from plumbum import cli, local
-from plumbum.cmd import mkdir, git, cmake  # pylint: disable=E0401
+from benchbuild.utils.cmd import mkdir, git, cmake  # pylint: disable=E0401
 
 from benchbuild.settings import CFG
 

--- a/benchbuild/container.py
+++ b/benchbuild/container.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from plumbum import cli, local, TF, FG, ProcessExecutionError
-from plumbum.cmd import tar, mkdir, mv, rm, bash
+from benchbuild.utils.cmd import tar, mkdir, mv, rm, bash
 from benchbuild import settings
 from benchbuild.utils import log
 from benchbuild.utils.bootstrap import find_package, install_uchroot

--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -31,7 +31,7 @@ from os import path, listdir
 import regex
 
 from plumbum import local
-from plumbum.cmd import mkdir, rmdir  # pylint: disable=E0401
+from benchbuild.utils.cmd import mkdir, rmdir  # pylint: disable=E0401
 from plumbum.commands.processes import ProcessExecutionError
 
 from benchbuild import projects
@@ -319,7 +319,7 @@ class RuntimeExperiment(Experiment):
         Args:
             project (Project):
                 Unused (deprecated).
-            calibrate_call (plumbum.cmd):
+            calibrate_call (benchbuild.utils.cmd):
                 The calibration command we will use.
         """
         with local.cwd(self.builddir):
@@ -341,7 +341,7 @@ class RuntimeExperiment(Experiment):
         Args:
             project (benchbuild.Project):
                 The calibration values will be assigned to this project.
-            cmd (plumbum.cmd):
+            cmd (benchbuild.utils.cmd):
                 The command we used to generate the calibration values.
             calibration (int):
                 The calibration time in nanoseconds.

--- a/benchbuild/experiments/papi.py
+++ b/benchbuild/experiments/papi.py
@@ -57,7 +57,7 @@ class PapiScopCoverage(RuntimeExperiment):
     def run(self):
         """Do the postprocessing, after all projects are done."""
         super(PapiScopCoverage, self).run()
-        from plumbum.cmd import pprof_analyze
+        from benchbuild.utils.cmd import pprof_analyze
 
         with local.env(BB_EXPERIMENT_ID=str(CFG["experiment_id"]),
                        BB_EXPERIMENT=self.name,
@@ -82,7 +82,7 @@ class PapiScopCoverage(RuntimeExperiment):
         p.runtime_extension = partial(run_with_time, p, self, CFG, 1)
 
         def evaluate_calibration(e):
-            from plumbum.cmd import pprof_calibrate
+            from benchbuild.utils.cmd import pprof_calibrate
             papi_calibration = e.get_papi_calibration(p, pprof_calibrate)
             e.persist_calibration(p, pprof_calibrate, papi_calibration)
 
@@ -123,7 +123,7 @@ class PapiStandardScopCoverage(PapiScopCoverage):
         p.runtime_extension = partial(run_with_time, p, self, CFG, 1)
 
         def evaluate_calibration(e):
-            from plumbum.cmd import pprof_calibrate
+            from benchbuild.utils.cmd import pprof_calibrate
             papi_calibration = e.get_papi_calibration(p, pprof_calibrate)
             e.persist_calibration(p, pprof_calibrate, papi_calibration)
 

--- a/benchbuild/experiments/polyjit.py
+++ b/benchbuild/experiments/polyjit.py
@@ -9,7 +9,7 @@ from os import path
 import copy
 import uuid
 
-from plumbum.cmd import rm, time  # pylint: disable=E0401
+from benchbuild.utils.cmd import rm, time  # pylint: disable=E0401
 from plumbum import local
 from benchbuild.experiments.compilestats import collect_compilestats
 from benchbuild.utils.actions import (RequireAll, Prepare, Build, Download, Configure,
@@ -201,7 +201,7 @@ def run_with_perf(project, experiment, config, jobs, run_f, args, **kwargs):
     from benchbuild.settings import CFG as c
     from benchbuild.utils.run import guarded_exec, handle_stdin
     from benchbuild.utils.db import persist_perf, persist_config
-    from plumbum.cmd import perf
+    from benchbuild.utils.cmd import perf
 
     c.update(config)
     project.name = kwargs.get("project_name", project.name)
@@ -449,7 +449,7 @@ class PJITpapi(PolyJIT):
         super(PJITpapi, self).run()
 
         from benchbuild.settings import CFG
-        from plumbum.cmd import pprof_analyze
+        from benchbuild.utils.cmd import pprof_analyze
 
         with local.env(BB_EXPERIMENT_ID=str(CFG["experiment_id"]),
                        BB_EXPERIMENT=self.name,

--- a/benchbuild/experiments/raw.py
+++ b/benchbuild/experiments/raw.py
@@ -21,7 +21,7 @@ from benchbuild.utils.actions import (Prepare, Build, Download, Configure, Clean
                                  MakeBuildDir, Run, Echo)
 from benchbuild.utils.run import guarded_exec, handle_stdin, fetch_time_output
 from benchbuild.utils.db import persist_time, persist_config
-from plumbum.cmd import time
+from benchbuild.utils.cmd import time
 
 from benchbuild.settings import CFG
 from benchbuild.utils.run import partial

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -4,8 +4,8 @@ Project handling for the benchbuild study.
 from os import path, listdir
 from abc import abstractmethod
 from plumbum import local
-from plumbum.cmd import mv, chmod, rm, mkdir, rmdir  # pylint: disable=E0401
 from benchbuild.settings import CFG
+from benchbuild.utils.cmd import mv, chmod, rm, mkdir, rmdir
 from benchbuild.utils.db import persist_project
 from benchbuild.utils.path import list_to_path
 from benchbuild.utils.run import in_builddir, unionfs

--- a/benchbuild/projects/benchbuild/bzip2.py
+++ b/benchbuild/projects/benchbuild/bzip2.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make, tar, cp
+from benchbuild.utils.cmd import make, tar, cp
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/ccrypt.py
+++ b/benchbuild/projects/benchbuild/ccrypt.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.compiler import lt_clang, lt_clang_cxx
 from os import path
 from plumbum import local
-from plumbum.cmd import ln, tar, make
+from benchbuild.utils.cmd import ln, tar, make
 
 
 class Ccrypt(BenchBuildGroup):

--- a/benchbuild/projects/benchbuild/crafty.py
+++ b/benchbuild/projects/benchbuild/crafty.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 from os import path
 from plumbum import local
-from plumbum.cmd import cat, make, unzip, mv
+from benchbuild.utils.cmd import cat, make, unzip, mv
 
 
 class Crafty(BenchBuildGroup):

--- a/benchbuild/projects/benchbuild/crocopat.py
+++ b/benchbuild/projects/benchbuild/crocopat.py
@@ -4,7 +4,7 @@ from benchbuild.utils.compiler import lt_clang_cxx
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 from plumbum import local
-from plumbum.cmd import cat, unzip, make
+from benchbuild.utils.cmd import cat, unzip, make
 from os import path
 from glob import glob
 

--- a/benchbuild/projects/benchbuild/ffmpeg.py
+++ b/benchbuild/projects/benchbuild/ffmpeg.py
@@ -4,7 +4,7 @@ from benchbuild.utils.compiler import lt_clang
 from benchbuild.utils.run import run
 from benchbuild.utils.downloader import Wget, Rsync
 from plumbum import local
-from plumbum.cmd import make, tar
+from benchbuild.utils.cmd import make, tar
 
 
 class LibAV(BenchBuildGroup):

--- a/benchbuild/projects/benchbuild/gzip.py
+++ b/benchbuild/projects/benchbuild/gzip.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import cp, make, tar
+from benchbuild.utils.cmd import cp, make, tar
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make, mkdir
+from benchbuild.utils.cmd import make, mkdir
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/lammps.py
+++ b/benchbuild/projects/benchbuild/lammps.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import cp, make
+from benchbuild.utils.cmd import cp, make
 
 from os import path
 from glob import glob

--- a/benchbuild/projects/benchbuild/lapack.py
+++ b/benchbuild/projects/benchbuild/lapack.py
@@ -5,7 +5,7 @@ from benchbuild.utils.compiler import lt_clang, lt_clang_cxx
 from benchbuild.utils.downloader import Git, Wget
 from benchbuild.utils.run import run
 from plumbum import local
-from plumbum.cmd import make, tar
+from benchbuild.utils.cmd import make, tar
 
 from os import path
 import logging

--- a/benchbuild/projects/benchbuild/leveldb.py
+++ b/benchbuild/projects/benchbuild/leveldb.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make
+from benchbuild.utils.cmd import make
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/linpack.py
+++ b/benchbuild/projects/benchbuild/linpack.py
@@ -3,7 +3,7 @@ from benchbuild.utils.compiler import lt_clang
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
-from plumbum.cmd import patch, cp
+from benchbuild.utils.cmd import patch, cp
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/mcrypt.py
+++ b/benchbuild/projects/benchbuild/mcrypt.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make, tar
+from benchbuild.utils.cmd import make, tar
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/minisat.py
+++ b/benchbuild/projects/benchbuild/minisat.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import git, make
+from benchbuild.utils.cmd import git, make
 
 from os import path, getenv
 from glob import glob

--- a/benchbuild/projects/benchbuild/openssl.py
+++ b/benchbuild/projects/benchbuild/openssl.py
@@ -5,7 +5,7 @@ from benchbuild.utils.run import run
 from benchbuild.project import wrap
 
 from plumbum import local
-from plumbum.cmd import tar, find, make
+from benchbuild.utils.cmd import tar, find, make
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/postgres.py
+++ b/benchbuild/projects/benchbuild/postgres.py
@@ -2,7 +2,7 @@ from benchbuild.projects.benchbuild.group import BenchBuildGroup
 from benchbuild.utils.run import run
 
 from plumbum import FG, local
-from plumbum.cmd import cp, echo, chmod
+from benchbuild.utils.cmd import cp, echo, chmod
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/povray.py
+++ b/benchbuild/projects/benchbuild/povray.py
@@ -5,8 +5,8 @@ from benchbuild.utils.downloader import Git, Wget
 from benchbuild.utils.run import run
 
 from plumbum import FG, local
-from plumbum.cmd import cp, find, tar, make, rm, head, grep, sed, sh
-from plumbum.cmd import mkdir
+from benchbuild.utils.cmd import cp, find, tar, make, rm, head, grep, sed, sh
+from benchbuild.utils.cmd import mkdir
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/python.py
+++ b/benchbuild/projects/benchbuild/python.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make, tar
+from benchbuild.utils.cmd import make, tar
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/rasdaman.py
+++ b/benchbuild/projects/benchbuild/rasdaman.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import autoreconf, make
+from benchbuild.utils.cmd import autoreconf, make
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import ruby, make, tar
+from benchbuild.utils.cmd import ruby, make, tar
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/sdcc.py
+++ b/benchbuild/projects/benchbuild/sdcc.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Svn
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make
+from benchbuild.utils.cmd import make
 
 
 class SDCC(BenchBuildGroup):

--- a/benchbuild/projects/benchbuild/sevenz.py
+++ b/benchbuild/projects/benchbuild/sevenz.py
@@ -4,7 +4,7 @@ from benchbuild.utils.compiler import lt_clang, lt_clang_cxx
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 from plumbum import local
-from plumbum.cmd import make, tar, cp
+from benchbuild.utils.cmd import make, tar, cp
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/sqlite3.py
+++ b/benchbuild/projects/benchbuild/sqlite3.py
@@ -5,7 +5,7 @@ from benchbuild.utils.compiler import lt_clang, lt_clang_cxx
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import unzip, make
+from benchbuild.utils.cmd import unzip, make
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/tcc.py
+++ b/benchbuild/projects/benchbuild/tcc.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import make, mkdir, tar
+from benchbuild.utils.cmd import make, mkdir, tar
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -6,7 +6,7 @@ from benchbuild.utils.downloader import Git
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import cp, make
+from benchbuild.utils.cmd import cp, make
 
 from os import path
 

--- a/benchbuild/projects/benchbuild/xz.py
+++ b/benchbuild/projects/benchbuild/xz.py
@@ -5,7 +5,7 @@ from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import tar, cp, make
+from benchbuild.utils.cmd import tar, cp, make
 
 from os import path
 

--- a/benchbuild/projects/gentoo/bzip2.py
+++ b/benchbuild/projects/gentoo/bzip2.py
@@ -8,7 +8,7 @@ from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, uchroot
 
-from plumbum.cmd import tar  # pylint: disable=E0401
+from benchbuild.utils.cmd import tar  # pylint: disable=E0401
 
 
 class BZip2(GentooGroup):

--- a/benchbuild/projects/gentoo/crafty.py
+++ b/benchbuild/projects/gentoo/crafty.py
@@ -8,7 +8,7 @@ from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, uchroot
 from plumbum import local
-from plumbum.cmd import cat  # pylint: disable=E0401
+from benchbuild.utils.cmd import cat  # pylint: disable=E0401
 
 
 class Crafty(GentooGroup):

--- a/benchbuild/projects/gentoo/gentoo.py
+++ b/benchbuild/projects/gentoo/gentoo.py
@@ -11,8 +11,8 @@ the gentoo image in benchbuild's source directory.
 
 """
 from os import path
-from plumbum.cmd import cp, tar, mv, grep, rm  # pylint: disable=E0401
-from plumbum.cmd import mkdir, curl, cut, tail, bash  # pylint: disable=E0401
+from benchbuild.utils.cmd import cp, tar, mv, grep, rm  # pylint: disable=E0401
+from benchbuild.utils.cmd import mkdir, curl, cut, tail, bash  # pylint: disable=E0401
 from plumbum import local
 from plumbum import TF, RETCODE
 from benchbuild.utils.compiler import wrap_cc_in_uchroot, wrap_cxx_in_uchroot

--- a/benchbuild/projects/gentoo/gzip.py
+++ b/benchbuild/projects/gentoo/gzip.py
@@ -7,7 +7,7 @@ from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, uchroot
 from plumbum import local
-from plumbum.cmd import tar  # pylint: disable=E0401
+from benchbuild.utils.cmd import tar  # pylint: disable=E0401
 
 
 class GZip(GentooGroup):

--- a/benchbuild/projects/gentoo/lammps.py
+++ b/benchbuild/projects/gentoo/lammps.py
@@ -8,7 +8,7 @@ from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, uchroot
 from plumbum import local
-from plumbum.cmd import tar  # pylint: disable=E0401
+from benchbuild.utils.cmd import tar  # pylint: disable=E0401
 
 
 class Lammps(GentooGroup):

--- a/benchbuild/projects/gentoo/postgresql.py
+++ b/benchbuild/projects/gentoo/postgresql.py
@@ -8,7 +8,7 @@ from benchbuild.project import wrap
 from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.run import run, uchroot
 from plumbum import local
-from plumbum.cmd import kill, mkdir  # pylint: disable=E0401
+from benchbuild.utils.cmd import kill, mkdir  # pylint: disable=E0401
 
 
 class Postgresql(GentooGroup):

--- a/benchbuild/projects/gentoo/xz.py
+++ b/benchbuild/projects/gentoo/xz.py
@@ -7,7 +7,7 @@ from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, uchroot
 from plumbum import local
-from plumbum.cmd import tar  # pylint: disable=E0401
+from benchbuild.utils.cmd import tar  # pylint: disable=E0401
 
 
 class XZ(GentooGroup):

--- a/benchbuild/projects/lnt/lnt.py
+++ b/benchbuild/projects/lnt/lnt.py
@@ -9,8 +9,8 @@ from benchbuild.utils.downloader import Git, CopyNoFail
 from benchbuild.utils.run import run
 
 from plumbum import local
-from plumbum.cmd import virtualenv
-from plumbum.cmd import mkdir, rm
+from benchbuild.utils.cmd import virtualenv
+from benchbuild.utils.cmd import mkdir, rm
 
 from os import path
 

--- a/benchbuild/projects/polybench/polybench.py
+++ b/benchbuild/projects/polybench/polybench.py
@@ -4,7 +4,7 @@ from benchbuild.utils.compiler import lt_clang
 from benchbuild.utils.downloader import Wget
 from benchbuild.utils.run import run, unionfs
 
-from plumbum.cmd import tar, cp
+from benchbuild.utils.cmd import tar, cp
 
 from os import path
 

--- a/benchbuild/run.py
+++ b/benchbuild/run.py
@@ -8,7 +8,7 @@ See the output of benchbuild run --help for more information.
 import os
 import sys
 from plumbum import cli
-from plumbum.cmd import mkdir  # pylint: disable=E0401
+from benchbuild.utils.cmd import mkdir  # pylint: disable=E0401
 from benchbuild.settings import CFG
 from benchbuild.utils.actions import Experiment
 from benchbuild.utils import user_interface as ui

--- a/benchbuild/run.py
+++ b/benchbuild/run.py
@@ -46,7 +46,8 @@ class BenchBuildRun(cli.Application):
     def projects(self, projects):
         self._project_names = projects
 
-    @cli.switch(["-L", "--list-experiments"], help="List available experiments")
+    @cli.switch(["-L", "--list-experiments"],
+                help="List available experiments")
     def list_experiments(self):
         self._list_experiments = True
 
@@ -61,8 +62,8 @@ class BenchBuildRun(cli.Application):
                            default=False)
 
     store_config = cli.Flag(["-s", "--save-config"],
-                           help="Save benchbuild's configuration.",
-                           default=False)
+                            help="Save benchbuild's configuration.",
+                            default=False)
 
     @cli.switch(["-G", "--group"],
                 str,
@@ -71,7 +72,7 @@ class BenchBuildRun(cli.Application):
     def group(self, group):
         self._group_name = group
 
-    pretend = cli.Flag(['p', 'pretend'], default = False)
+    pretend = cli.Flag(['p', 'pretend'], default=False)
 
     def main(self):
         """Main entry point of benchbuild run."""
@@ -115,7 +116,8 @@ class BenchBuildRun(cli.Application):
                 if sys.stdin.isatty():
                     response = ui.query_yes_no(
                         "The build directory {dirname} does not exist yet."
-                        "Should I create it?".format(dirname=builddir), "no")
+                        "Should I create it?".format(dirname=builddir),
+                        "no")
 
                 if response:
                     mkdir("-p", builddir)

--- a/benchbuild/test.py
+++ b/benchbuild/test.py
@@ -26,7 +26,7 @@ class BenchBuildTest(cli.Application):
     def get_check_line(self, name, module):
         from plumbum import local
         from benchbuild.utils.compiler import llvm, llvm_libs
-        from plumbum.cmd import sed, opt
+        from benchbuild.utils.cmd import sed, opt
 
         with local.env(LD_LIBRARY_PATH=llvm_libs()):
             if os.path.exists(opt_binary):
@@ -45,7 +45,7 @@ class BenchBuildTest(cli.Application):
 
     def main(self):
         from benchbuild.utils.schema import Session, RegressionTest
-        from plumbum.cmd import mkdir, sed
+        from benchbuild.utils.cmd import mkdir, sed
 
         prefix = CFG["regression-prefix"]
         if not os.path.exists(prefix):

--- a/benchbuild/utils/actions.py
+++ b/benchbuild/utils/actions.py
@@ -6,7 +6,7 @@ from benchbuild.utils.db import persist_experiment
 from benchbuild.utils.run import GuardedRunException
 
 from plumbum import local
-from plumbum.cmd import mkdir, rm
+from benchbuild.utils.cmd import mkdir, rm
 from plumbum import ProcessExecutionError
 from functools import partial, wraps
 from datetime import datetime

--- a/benchbuild/utils/bootstrap.py
+++ b/benchbuild/utils/bootstrap.py
@@ -10,7 +10,7 @@ ask = ui.ask
 
 def find_package(binary):
     try:
-        from plumbum import cmd
+        from benchbuild.utils import cmd
         cmd.__getattr__(binary)
     except AttributeError:
         print("Checking for {}  - No".format(binary))
@@ -47,7 +47,7 @@ PACKAGE_MANAGER = {
 
 
 def install_uchroot():
-    from plumbum.cmd import git, mkdir
+    from benchbuild.utils.cmd import git, mkdir
     builddir = settings.CFG["build_dir"].value()
     with local.cwd(builddir):
         if not os.path.exists("erlent/.git"):
@@ -57,7 +57,7 @@ def install_uchroot():
                 git("pull", "--rebase")
         mkdir("-p", "erlent/build")
         with local.cwd("erlent/build"):
-            from plumbum.cmd import cmake, make, cp
+            from benchbuild.utils.cmd import cmake, make, cp
             cmake("../")
             make()
     erlent_path = os.path.abspath(os.path.join(builddir, "erlent", "build"))
@@ -70,7 +70,7 @@ def install_uchroot():
 
 
 def check_uchroot_config():
-    from plumbum.cmd import grep
+    from benchbuild.utils.cmd import grep
     from getpass import getuser
     print("Checking configuration of 'uchroot'")
 

--- a/benchbuild/utils/cmd.py
+++ b/benchbuild/utils/cmd.py
@@ -1,0 +1,23 @@
+import sys
+
+__ALIASES__ = {"unionfs": ["unionfs_fuse", "unionfs"]}
+
+
+class CommandAlias:
+    def __getattr__(self, command):
+        """ Proxy getter for plumbum commands."""
+        from plumbum import cmd
+        check = [command]
+        if command in __ALIASES__:
+            check = __ALIASES__[command]
+
+        for alias_command in check:
+            try:
+                symbol = cmd.__getattr__(alias_command)
+                return symbol
+            except AttributeError:
+                pass
+        raise AttributeError
+
+
+sys.modules[__name__] = CommandAlias()

--- a/benchbuild/utils/compiler.py
+++ b/benchbuild/utils/compiler.py
@@ -79,7 +79,7 @@ def lt_clang(cflags, ldflags, func=None):
             way you can intercept the compilation process with arbitrary python
             code.
 
-    Returns (plumbum.cmd):
+    Returns (benchbuild.utils.cmd):
         Path to the new clang command.
     """
     from plumbum import local
@@ -103,7 +103,7 @@ def lt_clang_cxx(cflags, ldflags, func=None):
             way you can intercept the compilation process with arbitrary python
             code.
 
-    Returns (plumbum.cmd):
+    Returns (benchbuild.utils.cmd):
         Path to the new clang command.
     """
     from plumbum import local
@@ -124,7 +124,7 @@ def print_libtool_sucks_wrapper(filepath, cflags, ldflags, compiler, func,
         filepath (str): Path to the wrapper script.
         cflags (list(str)): The CFLAGS we want to hide.
         ldflags (list(str)): The LDFLAGS we want to hide.
-        compiler (plumbum.cmd): Real compiler command we should call in the
+        compiler (benchbuild.utils.cmd): Real compiler command we should call in the
             script.
         func: A function that will be pickled alongside the compiler.
             It will be called before the actual compilation took place. This
@@ -133,10 +133,10 @@ def print_libtool_sucks_wrapper(filepath, cflags, ldflags, compiler, func,
         compiler_ext_name: The name that we should give to the generated
             dill blob for :func:
 
-    Returns (plumbum.cmd):
+    Returns (benchbuild.utils.cmd):
         Command of the new compiler we can call.
     """
-    from plumbum.cmd import chmod
+    from benchbuild.utils.cmd import chmod
     import dill
     from os.path import abspath
 
@@ -168,7 +168,7 @@ import dill
 import functools
 from plumbum import ProcessExecutionError, local
 from plumbum.commands.modifiers import TEE
-from plumbum.cmd import timeout
+from benchbuild.utils.cmd import timeout
 from benchbuild.utils.run import GuardedRunException
 from benchbuild.utils import log
 

--- a/benchbuild/utils/downloader.py
+++ b/benchbuild/utils/downloader.py
@@ -62,7 +62,7 @@ def source_required(src_file, src_root):
             old_hash = h_file.readline()
         required = not new_hash == old_hash
         if required:
-            from plumbum.cmd import rm
+            from benchbuild.utils.cmd import rm
             rm("-r", src_dir)
             rm(hash_file)
     return required
@@ -95,7 +95,7 @@ def Copy(From, To):
         From (str): Path to the SOURCE.
         To (str): Path to the TARGET.
     """
-    from plumbum.cmd import cp
+    from benchbuild.utils.cmd import cp
     cp("-ar", "--reflink=auto", From, To)
 
 
@@ -138,7 +138,7 @@ def Wget(src_url, tgt_name, tgt_root=None):
         tgt_root = CFG["tmp_dir"].value()
 
     from os import path
-    from plumbum.cmd import wget
+    from benchbuild.utils.cmd import wget
 
     src_path = path.join(tgt_root, tgt_name)
     if not source_required(tgt_name, tgt_root):
@@ -164,7 +164,7 @@ def Git(src_url, tgt_name, tgt_root=None):
         tgt_root = CFG["tmp_dir"].value()
 
     from os import path
-    from plumbum.cmd import git
+    from benchbuild.utils.cmd import git
 
     src_dir = path.join(tgt_root, tgt_name)
     if not source_required(tgt_name, tgt_root):
@@ -190,7 +190,7 @@ def Svn(url, fname, to=None):
         to = CFG["tmp_dir"].value()
 
     from os import path
-    from plumbum.cmd import svn
+    from benchbuild.utils.cmd import svn
 
     src_dir = path.join(to, fname)
     if not source_required(fname, to):
@@ -216,7 +216,7 @@ def Rsync(url, tgt_name, tgt_root=None):
         tgt_root = CFG["tmp_dir"].value()
 
     from os import path
-    from plumbum.cmd import rsync
+    from benchbuild.utils.cmd import rsync
 
     src_dir = path.join(tgt_root, tgt_name)
     if not source_required(tgt_name, tgt_root):

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -2,7 +2,7 @@
 Experiment helpers
 """
 import os
-from plumbum.cmd import mkdir  # pylint: disable=E0401
+from benchbuild.utils.cmd import mkdir  # pylint: disable=E0401
 from contextlib import contextmanager
 from types import SimpleNamespace
 from benchbuild import settings
@@ -50,7 +50,7 @@ def handle_stdin(cmd, kwargs):
     into the plumbum command.
 
     Args:
-        cmd (plumbum.cmd): Command to wrap a stdin handler around.
+        cmd (benchbuild.utils.cmd): Command to wrap a stdin handler around.
         kwargs: Dictionary containing the kwargs.
             We check for they key `has_stdin`
 
@@ -328,7 +328,7 @@ def run(command, retcode=0):
 def uchroot_no_args():
     """Return the uchroot command without any customizations."""
     from plumbum import local
-    from plumbum.cmd import uchroot
+    from benchbuild.utils.cmd import uchroot
 
     return uchroot
 
@@ -395,7 +395,7 @@ def unionfs_tear_down(mountpoint, tries=3):
     """
     Tear down a unionfs mountpoint.
     """
-    from plumbum.cmd import fusermount, sync
+    from benchbuild.utils.cmd import fusermount, sync
     from plumbum import ProcessExecutionError
 
     if not os.path.exists(mountpoint):
@@ -431,7 +431,7 @@ def unionfs_set_up(ro_base, rw_image, mountpoint):
         log.error("Image dir does not exist: '{0}'".format(ro_base))
         raise ValueError("Image directory does not exist")
 
-    from plumbum.cmd import unionfs
+    from benchbuild.utils.cmd import unionfs
     ro_base = os.path.abspath(ro_base)
     rw_image = os.path.abspath(rw_image)
     mountpoint = os.path.abspath(mountpoint)

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -7,7 +7,7 @@ the SLURM controller either as batch or interactive script.
 import logging
 import os
 from plumbum import local
-from plumbum.cmd import bash, chmod, mkdir # pylint: disable=E0401
+from benchbuild.utils.cmd import bash, chmod, mkdir # pylint: disable=E0401
 from benchbuild.settings import CFG
 
 INFO = logging.info
@@ -105,7 +105,7 @@ def dump_slurm_script(script_name, benchbuild, experiment, projects):
 
     Args:
         script_name (str): name of the bash script.
-        commands (list(plumbum.cmd)): List of plumbum commands to write
+        commands (list(benchbuild.utils.cmd)): List of plumbum commands to write
             to the bash script.
         **kwargs: Dictionary with all environment variable bindings we should
             map in the bash script.

--- a/benchbuild/utils/versions.py
+++ b/benchbuild/utils/versions.py
@@ -1,7 +1,7 @@
 """Gather version information for BB."""
 
 from plumbum import local
-from plumbum.cmd import git
+from benchbuild.utils.cmd import git
 
 from benchbuild.settings import CFG
 from os import path


### PR DESCRIPTION
This enabled command aliasing (Example in benchbuild.utils.cmd)
Later commits might make this option configurable.