### PR TITLE
fix: deal with shell-escaped command line args

### DIFF
--- a/benchbuild/utils/templates/compiler.py.inc
+++ b/benchbuild/utils/templates/compiler.py.inc
@@ -6,7 +6,7 @@ import logging
 import dill
 from plumbum.commands.modifiers import TEE
 from plumbum import ProcessExecutionError
-from benchbuild.utils.cmd import timeout
+from benchbuild.utils.cmd import timeout, sh
 from benchbuild.utils import log
 
 os.environ["BB_CONFIG_FILE"] = "{CFG_FILE}"
@@ -58,6 +58,7 @@ def invoke_external_measurement(cmd):
 def run(cmd):
     fc = timeout["2m", cmd]
     fc = fc.with_env(**cmd.envvars)
+    fc = sh['-c', str(fc)]
     retcode, stdout, stderr = (fc & TEE)
     return (retcode, stdout, stderr)
 


### PR DESCRIPTION
Some tools pass in shell-escaped arguments. We need to make sure that those commands are processed by a shell
at some point. Therefore we wrap all compiler-calls in a call to 'sh -c'