### PR TITLE
slurm: fix 'rename all jobs' bug

### DIFF
--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -109,7 +109,7 @@ def dump_slurm_script(script_name, benchbuild, experiment, projects):
         slurm.write("export ")
         slurm.write(cfg_vars)
         slurm.write("\n")
-        slurm.write("scontrol update JobId=$SLURM_JOB_ID ")
+        slurm.write("scontrol update JobId=${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID} ")
         slurm.write("JobName=\"{0} $_project\"\n".format(experiment))
         slurm.write("\n")
         slurm.write("srun -c 1 hostname\n")


### PR DESCRIPTION
The last job in a slurm job array has the same ID as the whole array. Therefore,
renaming the last job
causes all jobs in a single array to be renamed.
Thanks to Stefan Kronawitter for the hint.