### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -24,7 +24,7 @@ class SpiderMonkey(BenchBuildGroup):
     src_uri = "https://github.com/mozilla/gecko-dev.git"
     src_dir = "gecko-dev.git"
     version = get_git_hash(src_uri)
-    if version == None:
+    if version is None:
         VERSION = None
     elif len(version) <= 7:
         VERSION = str(version)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:PolyJIT:benchbuild?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:PolyJIT:benchbuild?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)