### PR TITLE
Make benchbuild's settings extensible by projects/experiments/reports.

### DIFF
--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -1,0 +1,13 @@
+"""
+Setup plugins.
+"""
+from . import experiments as __EXPERIMENTS__
+from . import projects as __PROJECTS__
+from . import reports as __REPORTS__
+from .settings import CFG as __CFG__
+from .utils import settings as __SETTINGS__
+
+__EXPERIMENTS__.discover()
+__PROJECTS__.discover()
+__REPORTS__.discover()
+__SETTINGS__.setup_config(__CFG__)

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -255,24 +255,6 @@ CFG["slurm"] = {
     }
 }
 
-CFG["perf"] = {
-    "config": {
-        "default": None,
-        "desc": "A configuration for the pollyperformance experiment."
-    }
-}
-
-CFG["cs"] = {
-    "components": {
-        "default": None,
-        "desc": "List of filters for compilestats components."
-    },
-    "names": {
-        "default": None,
-        "desc": "List of filters for compilestats names."
-    }
-}
-
 CFG["uchroot"] = {
     "repo": {
         "default": "https://github.com/PolyJIT/erlent.git/",

--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -272,19 +272,6 @@ class Configuration():
                 for k in self.node:
                     self[k].init_from_env()
 
-    def update(self, cfg_dict):
-        """
-        Update the configuration dictionary with new content.
-
-        This just delegates the update down to the internal data structure.
-        No validation is done on the format, be sure you know what you do.
-
-        Args:
-            cfg_dict: A configuration dictionary.
-
-        """
-        self.node.update(cfg_dict.node)
-
     def value(self):
         """
         Return the node value, if we're a leaf node.


### PR DESCRIPTION
This adds extensibility to benchbuild's settings. You can add new configuration options for:
 - experiments
 - projects
 - reports.