### PR TITLE
Add payload support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -19,7 +19,7 @@ persistent=no
 load-plugins=
 
 # Use multiple processes to speed up Pylint.
-jobs=2
+jobs=1
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/benchbuild/extensions.py
+++ b/benchbuild/extensions.py
@@ -112,6 +112,7 @@ class RuntimeExtension(Extension):
                              **kwargs) as run:
             run_info = run()
             if self.config:
+                run_info.add_payload("config", self.config)
                 LOG.info(
                     yaml.dump(
                         self.config,

--- a/benchbuild/extensions.py
+++ b/benchbuild/extensions.py
@@ -112,16 +112,12 @@ class RuntimeExtension(Extension):
                              **kwargs) as run:
             run_info = run()
             if self.config:
-                LOG.info("")
-                LOG.info("==CONFIG==")
                 LOG.info(
                     yaml.dump(
                         self.config,
                         width=40,
                         indent=4,
                         default_flow_style=False))
-                LOG.info("==CONFIG==")
-                LOG.info("")
                 self.config['baseline'] = \
                     os.getenv("BB_IS_BASELINE", "False")
                 persist_config(run_info.db_run, run_info.session, self.config)
@@ -252,11 +248,7 @@ class ExtractCompileStats(Extension):
                 if res is not None:
                     yield res
 
-    def __call__(self,
-                 cc,
-                 *args,
-                 project=None,
-                 **kwargs):
+    def __call__(self, cc, *args, project=None, **kwargs):
         from benchbuild.experiments.compilestats import CompileStat
         from benchbuild.utils.db import persist_compilestats
         from benchbuild.utils.schema import Session

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -215,6 +215,7 @@ class RunInfo(object):
 
     db_run = attr.ib(init=False, default=None)
     session = attr.ib(init=False, default=None, repr=False)
+    payload = attr.ib(init=False, default=None, repr=False)
 
     def __attrs_post_init__(self):
         self.__begin(self.cmd, self.project, self.experiment.name,
@@ -224,17 +225,13 @@ class RunInfo(object):
         run_id = self.db_run.id
         settings.CFG["db"]["run_id"] = run_id
 
-    def __add__(self, rhs):
-        if rhs is None:
-            return self
-
-        new_run_info = RunInfo(
-            retcode=self.retcode + rhs.retcode,
-            stdout=self.stdout + rhs.stdout,
-            stderr=self.stderr + rhs.stderr,
-            db_run=[self.db_run, rhs.db_run],
-            session=self.session)
-        return new_run_info
+    def add_payload(self, name, payload):
+        if self == payload:
+            return
+        if not self.payload:
+            self.payload = {name: payload}
+        else:
+            self.payload.update({name: payload})
 
     @property
     def has_failed(self):

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -584,8 +584,8 @@ def unionfs_set_up(ro_base, rw_image, mountpoint):
     ro_base = os.path.abspath(ro_base)
     rw_image = os.path.abspath(rw_image)
     mountpoint = os.path.abspath(mountpoint)
-    return unionfs_cmd["-f", "-o", "auto_unmount,allow_other,cow",
-                       rw_image + "=RW:" + ro_base + "=RO", mountpoint]
+    return unionfs_cmd["-f", "-o", "auto_unmount,allow_other,cow", rw_image +
+                       "=RW:" + ro_base + "=RO", mountpoint]
 
 
 def unionfs_is_active(root):

--- a/benchbuild/utils/schema.py
+++ b/benchbuild/utils/schema.py
@@ -335,9 +335,15 @@ def needed_schema(connection, meta):
         sys.exit(-4)
     except sa.exc.OperationalError:
         # SQLite throws an OperationalError
+
+        # Now try again to add user-defined tables unconditionally.
+        meta.create_all(connection, checkfirst=True)
         return False
     except sa.exc.ProgrammingError:
         # PostgreSQL throws a ProgrammingError
+
+        # Now try again to add user-defined tables unconditionally.
+        meta.create_all(connection, checkfirst=True)
         return False
     return True
 


### PR DESCRIPTION
This adds support for payloads to the RunInfo objects that can be obtained from tracked
runs. Every extension is now capable of adding arbitrary objects to the payload dictionary included in the RunInfo object.
You can use this to transport results between extensions.

This Pull Request includes a fix for a problem with custom schema creation.