### PR TITLE
[utils] Generalize setup_config to enable use from other projects.

### DIFF
--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -568,7 +568,7 @@ def find_config(test_file=None, defaults=None, root=os.curdir):
             return ret
 
 
-def setup_config(cfg, env_var_name=None):
+def setup_config(cfg, config_filenames=None, env_var_name=None):
     """
     This will initialize the given configuration object.
 
@@ -580,13 +580,17 @@ def setup_config(cfg, env_var_name=None):
     WARNING: Environment variables do _not_ take precedence over the config
              file right now. (init_from_env will refuse to update the
              value, if there is already one.)
+
+    Args:
+        config_filenames: list of possible config filenames
+        env_var_name: name of the environment variable holding the config path
     """
     if env_var_name is None:
         env_var_name = "BB_CONFIG_FILE"
 
     config_path = os.getenv(env_var_name, None)
     if not config_path:
-        config_path = find_config()
+        config_path = find_config(defaults=config_filenames)
 
     if config_path:
         cfg.load(config_path)

--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -532,7 +532,7 @@ def path_constructor(loader, node):
     return ConfigPath(value)
 
 
-def __find_config__(test_file=None, defaults=None, root=os.curdir):
+def find_config(test_file=None, defaults=None, root=os.curdir):
     """
     Find the path to the default config file.
 
@@ -568,7 +568,7 @@ def __find_config__(test_file=None, defaults=None, root=os.curdir):
             return ret
 
 
-def setup_config(cfg):
+def setup_config(cfg, env_var_name=None):
     """
     This will initialize the given configuration object.
 
@@ -581,9 +581,12 @@ def setup_config(cfg):
              file right now. (init_from_env will refuse to update the
              value, if there is already one.)
     """
-    config_path = os.getenv("BB_CONFIG_FILE", None)
+    if env_var_name is None:
+        env_var_name = "BB_CONFIG_FILE"
+
+    config_path = os.getenv(env_var_name, None)
     if not config_path:
-        config_path = __find_config__()
+        config_path = find_config()
 
     if config_path:
         cfg.load(config_path)


### PR DESCRIPTION
Generalize setup_config by making the name of the environment variable
a parameter. Fix visability of find_config function.