### PR TITLE
Fix: Crash on empty version list

### DIFF
--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -184,7 +184,14 @@ class Experiment(metaclass=ExperimentRegistry):
                 * for version in versions:
                     version in prj_cls.versions()
         """
-        head, *tail = versions if versions else prj_cls.versions()
+        if versions is None:
+            versions = prj_cls.versions()
+
+        if not versions:
+            # early return if version list is empty
+            return
+
+        head, *tail = versions
 
         yield head
         if bool(CFG["versions"]["full"]):


### PR DESCRIPTION
Prevent BB from crashing if the project returned a empty version list.
In this case we process nothing and continue with the next project.

resolves se-passau/VaRA#414