### PR TITLE
Fix wrong error tracking introduced by multiprocessing support.

### DIFF
--- a/benchbuild/cli/run.py
+++ b/benchbuild/cli/run.py
@@ -59,12 +59,6 @@ class BenchBuildRun(cli.Application):
 
     pretend = cli.Flag(['p', 'pretend'], default=False)
 
-    def __generate_plan(self, exps, prjs):
-        for exp_cls in exps.values():
-            exp = exp_cls(projects=prjs)
-            eactn = actions.Experiment(obj=exp, actions=exp.actions())
-            yield eactn
-
     @staticmethod
     def setup_progress(cfg, num_actions):
         """Setup a progress bar.
@@ -118,7 +112,7 @@ class BenchBuildRun(cli.Application):
             print("Could not find any experiment. Exiting.")
             return -2
 
-        plan = list(self.__generate_plan(exps, prjs))
+        plan = list(tasks.generate_plan(exps, prjs))
         num_actions = actions.num_steps(plan)
         actions.print_steps(plan)
 

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -352,6 +352,8 @@ def populate(projects_to_filter=None, group=None):
         group (list(str)):
             In addition to the project filter, we provide a way to filter
             whole groups.
+    Returns:
+        a dictionary of (project name, project class) pairs.
     """
     if projects_to_filter is None:
         projects_to_filter = []

--- a/benchbuild/utils/actions.py
+++ b/benchbuild/utils/actions.py
@@ -427,8 +427,9 @@ class Experiment(Any):
 
         try:
             with mp.Pool(num_processes) as pool:
-                results = itertools.chain.from_iterable(
-                    pool.map(run_any_child, actions))
+                results = list(
+                    itertools.chain.from_iterable(
+                        pool.map(run_any_child, actions)))
         except KeyboardInterrupt:
             LOG.info("Experiment aborting by user request")
             results.append(StepResult.ERROR)

--- a/benchbuild/utils/tasks.py
+++ b/benchbuild/utils/tasks.py
@@ -15,3 +15,21 @@ def execute_plan(plan):
     """
     results = [action() for action in plan]
     return [result for result in results if actns.step_has_failed(result)]
+
+
+def generate_plan(exps, prjs):
+    """
+    Generate an execution plan for the given experimetns and projects.
+
+    Args:
+        exps: dictionary of experiment names and their associated experiment
+              class.
+        prjs: list of projects to populate each experiment with.
+
+    Returns:
+        a list of experiment actions suitable for execution.
+    """
+    for exp_cls in exps.values():
+        exp = exp_cls(projects=prjs)
+        eactn = actns.Experiment(obj=exp, actions=exp.actions())
+        yield eactn

--- a/tests/test_213_error_tracking.py
+++ b/tests/test_213_error_tracking.py
@@ -1,0 +1,82 @@
+"""
+Test issue 213: Wrong error tracking for failed commands
+"""
+import attr
+import unittest
+import logging
+
+from plumbum import ProcessExecutionError
+
+from benchbuild import project
+from benchbuild import experiment
+from benchbuild.utils import actions as a
+from benchbuild.utils import tasks
+
+
+@attr.s
+class Issue213a(a.Step):
+    @a.notify_step_begin_end
+    def __call__(self):
+        raise ProcessExecutionError([], 1, "", "")
+
+
+@attr.s
+class Issue213b(a.Step):
+    @a.notify_step_begin_end
+    def __call__(self):
+        return a.StepResult.ERROR
+
+
+class EmptyProject(project.Project):
+    NAME = "test_empty"
+    DOMAIN = "debug"
+    GROUP = "debug"
+    SRC_FILE = "none"
+
+    def compile(self):
+        pass
+
+    def configure(self):
+        pass
+
+
+@attr.s
+class ExceptionExp(experiment.Experiment):
+    NAME = "test_exception"
+
+    def actions_for_project(self, project):
+        return [Issue213a(obj=project)]
+
+
+@attr.s
+class ErrorStateExp(experiment.Experiment):
+    NAME = "test_error_state"
+
+    def actions_for_project(self, project):
+        return [Issue213b(obj=project)]
+
+
+LOG = logging.getLogger(__name__)
+
+class TrackErrorsTestCase(unittest.TestCase):
+    def test_exception(self):
+        plan = list(
+            tasks.generate_plan({"test_exception": ExceptionExp},
+                                {"test_empty": EmptyProject}))
+        self.assertEqual(len(plan),
+                         1,
+                         msg="The test plan must have a length of 1.")
+
+        failed = tasks.execute_plan(plan)
+        self.assertEqual(len(failed), 1, msg="One step must fail!")
+
+    def test_error_state(self):
+        plan = list(
+            tasks.generate_plan({"test_error_state": ErrorStateExp},
+                                {"test_empty": EmptyProject}))
+        self.assertEqual(len(plan),
+                         1,
+                         msg="The test plan must have a length of 1.")
+
+        failed = tasks.execute_plan(plan)
+        self.assertEqual(len(failed), 1, msg="One step must fail!")


### PR DESCRIPTION
This set of patches reproduce and fix the error introduced by using itertools.chain objects to collect the return results of all running processes.

As a simple fix, we just convert the chain iterable to a proper list and call it a day ;-).