### PR TITLE
new tasks implementation (incomplete)

### DIFF
--- a/benchbuild/tasks/__init__.py
+++ b/benchbuild/tasks/__init__.py
@@ -1,0 +1,32 @@
+"""
+Benchbuild's tasks API
+
+Base types:
+    Task
+    TaskGroup
+    TaskManager
+    TaskPolicy
+
+Task groups:
+    fail_group
+    continue_group
+
+Tasks:
+    clean
+    clean_extra
+    compile_project
+    echo
+    make_builddir
+    manage_experiment
+    run_project
+
+Context managers:
+    ExperimentTransaction
+    LogTasks
+"""
+
+from .actions import TaskPolicy, TaskGroup, Task, TaskManager
+from .actions import fail_group, continue_group
+from .actions import (echo, run_project, compile_project, make_builddir,
+                      clean_extra, clean, manage_experiment)
+from .actions import ExperimentTransaction, LogTasks

--- a/benchbuild/tasks/actions.py
+++ b/benchbuild/tasks/actions.py
@@ -2,10 +2,11 @@
 import itertools
 import logging
 import os
+import textwrap
 from abc import abstractmethod
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from datetime import datetime
-from typing import List, Union, Iterable
+from typing import Iterable, List, Union
 
 import attr
 import sqlalchemy as sa
@@ -20,49 +21,66 @@ from benchbuild.utils.cmd import mkdir, rm, rmdir
 
 LOG = logging.getLogger(__name__)
 
+@attr.s
+class NamedTaskEntity:
+    def __attrs_post_init__(self):
+        self.name: str = type(self).__name__
+        self.description: str = type(self).__doc__
 
 @attr.s
-class GroupPolicy:
+class GroupPolicy(NamedTaskEntity):
     children: List[Union['GroupPolicy', 'Task']] = attr.ib()
     state: StepResult = attr.ib(kw_only=True, default=StepResult.OK)
 
     def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
         for child in self.children:
             child.owner = self
 
     @abstractmethod
-    def can_continue(self, step_result):
-        pass
+    def can_continue(self, task_result: StepResult) -> bool:
+        ...
 
     def tasks(self):
         all_tasks = [child.tasks() for child in self.children]
         return list(itertools.chain(*all_tasks))
 
+    def __str__(self, indent=0) -> str:
+        ret_str = textwrap.indent(
+            "* {name}: {desc}\n".format(name=self.name, desc=self.description),
+            indent * ' ')
+        ret_str += "\n".join([
+            textwrap.indent(child.__str__(indent=indent + 1), indent * " ")
+            for child in self.children
+        ])
+        return ret_str
+
 
 @attr.s
 class FailOnError(GroupPolicy):
-    def can_continue(self, task_result):
+    def can_continue(self, task_result: StepResult) -> bool:
         res = task_result in [StepResult.OK, StepResult.CAN_CONTINUE]
         if not res:
-            self.state = res
+            self.state = task_result
 
         return self.state in [StepResult.OK, StepResult.CAN_CONTINUE]
 
 
 @attr.s
 class ContinueOnError(GroupPolicy):
-    def can_continue(self, step_result):
-        self.state = step_result
+    def can_continue(self, task_result: StepResult) -> bool:
+        self.state = task_result
         return True
 
 @attr.s
-class Task:
+class Task(NamedTaskEntity):
     def __attrs_post_init__(self):
-        self.name: str = type(self).__name__
-        self.description: str = type(self).__doc__
+        super().__attrs_post_init__()
+
         self.owner: 'GroupPolicy' = None
 
-    def catch_exceptions(self, task):
+    def catch_exceptions(self, task: 'Task') -> StepResult:
         try:
             result = task()
         except (ProcessExecutionError, KeyboardInterrupt, OSError) as ex:
@@ -72,26 +90,29 @@ class Task:
         return result
 
     @abstractmethod
-    def on_error(self, step_result, exception=None):
+    def on_error(self, task_result: StepResult, exception=None):
         """What do we do with an error."""
-        pass
 
     @abstractmethod
-    def on_result(self, step_result):
+    def on_result(self, task_result: StepResult):
         """What do we do with a result."""
-        pass
 
-    def can_continue(self, step_result):
+    def can_continue(self, task_result: StepResult) -> bool:
         """Can execution of multiple child steps continue?"""
         if self.owner:
-            return self.owner.can_continue(step_result)
+            return self.owner.can_continue(task_result)
         return True
 
-    def tasks(self):
+    def tasks(self) -> List[Union['Task', GroupPolicy]]:
         return [self]
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self) -> StepResult:
         """Perform actions that define this step implementation."""
+
+    def __str__(self, indent=0):
+        return textwrap.indent(
+            "* {name}: {desc}".format(name=self.name, desc=self.description),
+            indent * ' ')
 
 
 @attr.s
@@ -103,13 +124,16 @@ class Echo(Task):
         LOG.info(self.message)
         return StepResult.OK
 
+    def __str__(self, indent=0):
+        return textwrap.indent(self.message, indent * ' ')
+
 
 @attr.s
 class Run(Task):
     """Run a project."""
     project: Project = attr.ib()
 
-    def __call__(self):
+    def __call__(self) -> StepResult:
         result = self.project.run()
         return result
 
@@ -118,7 +142,7 @@ class Compile(Task):
     """Compile the project."""
     project: Project = attr.ib()
 
-    def __call__(self):
+    def __call__(self) -> StepResult:
         result = self.project.compile()
         return result
 
@@ -127,9 +151,10 @@ class MakeBuildDir(Task):
     """Create the build directory."""
     project: Project = attr.ib()
 
-    def __call__(self):
+    def __call__(self) -> StepResult:
         if not os.path.exists(self.project.builddir):
             mkdir("-p", self.project.builddir)
+        return StepResult.OK
 
 @attr.s
 class Clean(Task):
@@ -156,10 +181,10 @@ class Clean(Task):
                 else:
                     umount_paths.append(part.mountpoint)
 
-    def __call__(self):
+    def __call__(self) -> StepResult:
         if not CFG['clean']:
             LOG.warning("Clean disabled by config.")
-            return
+            return StepResult.CAN_CONTINUE
         obj_builddir = os.path.abspath(self.project.builddir)
         if os.path.exists(obj_builddir):
             LOG.debug("Path %s exists", obj_builddir)
@@ -170,12 +195,12 @@ class Clean(Task):
                 rm("-rf", obj_builddir)
         else:
             LOG.debug("Path %s did not exist anymore", obj_builddir)
-        self.status = StepResult.OK
+        return StepResult.OK
 
 @attr.s
 class CleanExtra(Task):
     """Cleans the extra directories."""
-    def __call__(self):
+    def __call__(self) -> StepResult:
         if not CFG['clean']:
             return StepResult.OK
 
@@ -183,16 +208,19 @@ class CleanExtra(Task):
         for p in paths:
             if os.path.exists(p):
                 rm("-r", p)
+        return StepResult.OK
+
+
 
 @attr.s
-class TaskManager:
+class TaskManager(NamedTaskEntity):
     plan: Union['GroupPolicy', 'Task'] = attr.ib()
 
     def __merge_results__(self, results, merge_results):
         if isinstance(merge_results, Iterable):
             return list(itertools.chain(results, merge_results))
 
-        new_results = results 
+        new_results = results
         new_results.append(merge_results)
         return new_results
 
@@ -209,13 +237,38 @@ class TaskManager:
 
     @contextmanager
     def execution_context(self, task: Task):
-        yield task
+        log_ctx = LogTasks(task)
+
+        mgrs = [
+            log_ctx
+        ]
+
+        with ExitStack() as stack:
+            for mgr in mgrs:
+                stack.enter_context(mgr)
+            yield task
+
+    def __str__(self, indent=0):
+        ret_str = textwrap.indent(
+            "* {name}: {desc}\n".format(name=self.name,
+                                        desc=self.description), indent * ' ')
+        ret_str += self.plan.__str__(indent=indent+1)
+        return ret_str
 
 @attr.s
 class Experiment(TaskManager, Task):
     """Run an experiment, wrapped in a db transaction."""
     experiment = attr.ib()
-    plan: List[Union['GroupPolicy', 'Task']] = attr.ib()
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        name = self.experiment.name
+        self.plan = FailOnError([
+            Echo(message="Start experiment: {0}".format(name)),
+            self.plan,
+            Echo(message="Completed experiment: {0}".format(name))
+        ])
+
 
     def begin_transaction(self):
         experiment, session = db.persist_experiment(self.experiment)
@@ -248,21 +301,22 @@ class Experiment(TaskManager, Task):
             LOG.error(inv_req)
 
     @contextmanager
-    def execution_context(self, task: Task):
+    def execution_context(self, task: Task) -> List[AbstractContextManager]:
         experiment, session = self.begin_transaction()
         yield task
         self.end_transaction(experiment, session)
 
-    def __extended_plan__(self):
-        name = self.experiment.name
-        extended_plan = FailOnError([
-            Echo(message="Start experiment: {0}".format(name)),
-            self.plan,
-            Echo(message="Completed experiment: {0}".format(name))
-        ])
-        return extended_plan
-
-    def __call__(self):
-        self.plan = self.__extended_plan__()
+    def __call__(self) -> StepResult:
         results = self.run()
         return results
+
+
+@attr.s
+class LogTasks(AbstractContextManager):
+    task: Task = attr.ib()
+
+    def __enter__(self):
+        LOG.info("\n%s - %s", self.task.name, self.task.description)
+
+    def __exit__(self, type, value, traceback):
+        LOG.info("%s COMPLETE")

--- a/benchbuild/tasks/actions.py
+++ b/benchbuild/tasks/actions.py
@@ -1,0 +1,268 @@
+"""New actions implementation."""
+import itertools
+import logging
+import os
+from abc import abstractmethod
+from contextlib import contextmanager
+from datetime import datetime
+from typing import List, Union, Iterable
+
+import attr
+import sqlalchemy as sa
+from plumbum import ProcessExecutionError
+
+from benchbuild import signals
+from benchbuild.project import Project
+from benchbuild.settings import CFG
+from benchbuild.utils import db
+from benchbuild.utils.actions import StepResult
+from benchbuild.utils.cmd import mkdir, rm, rmdir
+
+LOG = logging.getLogger(__name__)
+
+
+@attr.s
+class GroupPolicy:
+    children: List[Union['GroupPolicy', 'Task']] = attr.ib()
+    state: StepResult = attr.ib(kw_only=True, default=StepResult.OK)
+
+    def __attrs_post_init__(self):
+        for child in self.children:
+            child.owner = self
+
+    @abstractmethod
+    def can_continue(self, step_result):
+        pass
+
+    def tasks(self):
+        all_tasks = [child.tasks() for child in self.children]
+        return list(itertools.chain(*all_tasks))
+
+
+@attr.s
+class FailOnError(GroupPolicy):
+    def can_continue(self, task_result):
+        res = task_result in [StepResult.OK, StepResult.CAN_CONTINUE]
+        if not res:
+            self.state = res
+
+        return self.state in [StepResult.OK, StepResult.CAN_CONTINUE]
+
+
+@attr.s
+class ContinueOnError(GroupPolicy):
+    def can_continue(self, step_result):
+        self.state = step_result
+        return True
+
+@attr.s
+class Task:
+    def __attrs_post_init__(self):
+        self.name: str = type(self).__name__
+        self.description: str = type(self).__doc__
+        self.owner: 'GroupPolicy' = None
+
+    def catch_exceptions(self, task):
+        try:
+            result = task()
+        except (ProcessExecutionError, KeyboardInterrupt, OSError) as ex:
+            task.on_error(result, ex)
+            result = StepResult.ERROR
+
+        return result
+
+    @abstractmethod
+    def on_error(self, step_result, exception=None):
+        """What do we do with an error."""
+        pass
+
+    @abstractmethod
+    def on_result(self, step_result):
+        """What do we do with a result."""
+        pass
+
+    def can_continue(self, step_result):
+        """Can execution of multiple child steps continue?"""
+        if self.owner:
+            return self.owner.can_continue(step_result)
+        return True
+
+    def tasks(self):
+        return [self]
+
+    def __call__(self, *args, **kwargs):
+        """Perform actions that define this step implementation."""
+
+
+@attr.s
+class Echo(Task):
+    """Print a message."""
+    message: str = attr.ib(kw_only=True)
+
+    def __call__(self) -> StepResult:
+        LOG.info(self.message)
+        return StepResult.OK
+
+
+@attr.s
+class Run(Task):
+    """Run a project."""
+    project: Project = attr.ib()
+
+    def __call__(self):
+        result = self.project.run()
+        return result
+
+@attr.s
+class Compile(Task):
+    """Compile the project."""
+    project: Project = attr.ib()
+
+    def __call__(self):
+        result = self.project.compile()
+        return result
+
+@attr.s
+class MakeBuildDir(Task):
+    """Create the build directory."""
+    project: Project = attr.ib()
+
+    def __call__(self):
+        if not os.path.exists(self.project.builddir):
+            mkdir("-p", self.project.builddir)
+
+@attr.s
+class Clean(Task):
+    """Clean the build directory."""
+    project: Project = attr.ib()
+    check_empty: bool = attr.ib(default=False)
+
+    @staticmethod
+    def clean_mountpoints(root: str):
+        """
+        Unmount any remaining mountpoints under :root.
+
+        Args:
+            root: All UnionFS-mountpoints under this directory will be
+                  unmounted.
+        """
+        import psutil
+        umount_paths = []
+        real_root = os.path.realpath(root)
+        for part in psutil.disk_partitions(all=True):
+            if os.path.commonpath([part.mountpoint, real_root]) == real_root:
+                if not part.fstype == "fuse.unionfs":
+                    LOG.error("NON-UnionFS mountpoint found under %s", root)
+                else:
+                    umount_paths.append(part.mountpoint)
+
+    def __call__(self):
+        if not CFG['clean']:
+            LOG.warning("Clean disabled by config.")
+            return
+        obj_builddir = os.path.abspath(self.project.builddir)
+        if os.path.exists(obj_builddir):
+            LOG.debug("Path %s exists", obj_builddir)
+            Clean.clean_mountpoints(obj_builddir)
+            if self.check_empty:
+                rmdir(obj_builddir, retcode=None)
+            else:
+                rm("-rf", obj_builddir)
+        else:
+            LOG.debug("Path %s did not exist anymore", obj_builddir)
+        self.status = StepResult.OK
+
+@attr.s
+class CleanExtra(Task):
+    """Cleans the extra directories."""
+    def __call__(self):
+        if not CFG['clean']:
+            return StepResult.OK
+
+        paths = CFG["cleanup_paths"].value
+        for p in paths:
+            if os.path.exists(p):
+                rm("-r", p)
+
+@attr.s
+class TaskManager:
+    plan: Union['GroupPolicy', 'Task'] = attr.ib()
+
+    def __merge_results__(self, results, merge_results):
+        if isinstance(merge_results, Iterable):
+            return list(itertools.chain(results, merge_results))
+
+        new_results = results 
+        new_results.append(merge_results)
+        return new_results
+
+    def run(self):
+        res = StepResult.OK
+        results = []
+        for task in self.plan.tasks():
+            if task.can_continue(res):
+                with self.execution_context(task) as task_context:
+                    res = task_context()
+
+            results = self.__merge_results__(results, res)
+        return results
+
+    @contextmanager
+    def execution_context(self, task: Task):
+        yield task
+
+@attr.s
+class Experiment(TaskManager, Task):
+    """Run an experiment, wrapped in a db transaction."""
+    experiment = attr.ib()
+    plan: List[Union['GroupPolicy', 'Task']] = attr.ib()
+
+    def begin_transaction(self):
+        experiment, session = db.persist_experiment(self.experiment)
+        if experiment.begin is None:
+            experiment.begin = datetime.now()
+        else:
+            experiment.begin = min(experiment.begin, datetime.now())
+        session.add(experiment)
+        try:
+            session.commit()
+        except sa.orm.exc.StaleDataError:
+            LOG.error("Transaction isolation level caused a StaleDataError")
+
+        # React to external signals
+        signals.handlers.register(Experiment.end_transaction, experiment,
+                                  session)
+
+        return experiment, session
+
+    @staticmethod
+    def end_transaction(experiment, session):
+        try:
+            if experiment.end is None:
+                experiment.end = datetime.now()
+            else:
+                experiment.end = max(experiment.end, datetime.now())
+            session.add(experiment)
+            session.commit()
+        except sa.exc.InvalidRequestError as inv_req:
+            LOG.error(inv_req)
+
+    @contextmanager
+    def execution_context(self, task: Task):
+        experiment, session = self.begin_transaction()
+        yield task
+        self.end_transaction(experiment, session)
+
+    def __extended_plan__(self):
+        name = self.experiment.name
+        extended_plan = FailOnError([
+            Echo(message="Start experiment: {0}".format(name)),
+            self.plan,
+            Echo(message="Completed experiment: {0}".format(name))
+        ])
+        return extended_plan
+
+    def __call__(self):
+        self.plan = self.__extended_plan__()
+        results = self.run()
+        return results

--- a/benchbuild/tasks/actions.py
+++ b/benchbuild/tasks/actions.py
@@ -160,7 +160,7 @@ def __print_ident__(name: str, description: str, indent: int = 0) -> str:
         "* {name}: {desc}".format(name=name, desc=description), indent * ' ')
 
 
-def catch_exceptions(task: 'Task'):
+def __catch_exceptions__(task: 'Task'):
     try:
         result = task()
     except (ProcessExecutionError, KeyboardInterrupt, OSError) as ex:
@@ -172,7 +172,7 @@ def catch_exceptions(task: 'Task'):
 
 
 @contextmanager
-def per_task_context(context, task: Task):
+def __per_task_context__(context, task: Task):
     with ExitStack() as stack:
         for mgr in context:
             stack.enter_context(mgr(task))
@@ -180,7 +180,7 @@ def per_task_context(context, task: Task):
 
 
 @contextmanager
-def global_context(context):
+def __global_context__(context):
     with ExitStack() as stack:
         for mgr in context:
             stack.enter_context(mgr)
@@ -212,11 +212,11 @@ class TaskManager:
         res = StepResult.OK
         results = []
 
-        with global_context(self.global_context):
+        with __global_context__(self.global_context):
             for task in self.plan.tasks():
                 if task.can_continue(res):
-                    with per_task_context(self.task_context,
-                                          task) as task_context:
+                    with __per_task_context__(self.task_context,
+                                              task) as task_context:
                         res = task_context()
                 results = __merge_results__(results, res)
         return results

--- a/benchbuild/tasks/actions.py
+++ b/benchbuild/tasks/actions.py
@@ -71,6 +71,11 @@ class TaskGroup:
     children: ChildTasks
     policy: TaskPolicy
 
+    def __attrs_post_init__(self):
+        for child in self.children:
+            if isinstance(child, Task):
+                child.owner = self
+
     def on_error(self, task_result: StepResult, exception=None):
         """What do we do with an error."""
         return self.policy.on_error(task_result, exception)

--- a/benchbuild/tasks/actions.py
+++ b/benchbuild/tasks/actions.py
@@ -4,9 +4,9 @@ import logging
 import os
 import textwrap
 from abc import abstractmethod
-from contextlib import AbstractContextManager, ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime
-from typing import Iterable, List, Union
+from typing import Iterable, List, Callable, Union
 
 import attr
 import sqlalchemy as sa
@@ -14,6 +14,7 @@ from plumbum import ProcessExecutionError
 
 from benchbuild import signals
 from benchbuild.project import Project
+from benchbuild.experiment import Experiment
 from benchbuild.settings import CFG
 from benchbuild.utils import db
 from benchbuild.utils.actions import StepResult
@@ -21,44 +22,83 @@ from benchbuild.utils.cmd import mkdir, rm, rmdir
 
 LOG = logging.getLogger(__name__)
 
-@attr.s
-class NamedTaskEntity:
-    def __attrs_post_init__(self):
-        self.name: str = type(self).__name__
-        self.description: str = type(self).__doc__
+RunnableTask = Union['Task', 'TaskGroup', 'TaskManager']
+ChildTasks = List[RunnableTask]
 
-@attr.s
-class GroupPolicy(NamedTaskEntity):
-    children: List[Union['GroupPolicy', 'Task']] = attr.ib()
-    state: StepResult = attr.ib(kw_only=True, default=StepResult.OK)
 
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
+class TaskPolicy:
+    state: StepResult = attr.ib(default=StepResult.OK)
 
-        for child in self.children:
-            child.owner = self
+    def on_error(self, task_result: StepResult, exception=None):
+        """What do we do with an error."""
+
+    def on_result(self, task_result: StepResult):
+        """What do we do with a result."""
 
     @abstractmethod
     def can_continue(self, task_result: StepResult) -> bool:
-        ...
+        """Can execution of multiple child steps continue?"""
+
+
+@attr.s
+class TaskGroup:
+    name: str = attr.ib()
+    description: str = attr.ib()
+    children: ChildTasks = attr.ib()
+    policy: TaskPolicy = attr.ib()
+
+    def on_error(self, task_result: StepResult, exception=None):
+        """What do we do with an error."""
+        return self.policy.on_error(task_result, exception)
+
+    def on_result(self, task_result: StepResult):
+        """What do we do with a result."""
+        return self.policy.on_result(task_result)
+
+    def can_continue(self, task_result: StepResult) -> bool:
+        """Can execution of multiple child steps continue?"""
+        return self.policy.can_continue(task_result)
 
     def tasks(self):
-        all_tasks = [child.tasks() for child in self.children]
+        all_tasks = [
+            child.tasks() if hasattr(child, 'tasks') else [child]
+            for child in self.children
+        ]
         return list(itertools.chain(*all_tasks))
 
-    def __str__(self, indent=0) -> str:
-        ret_str = textwrap.indent(
-            "* {name}: {desc}\n".format(name=self.name, desc=self.description),
-            indent * ' ')
-        ret_str += "\n".join([
-            textwrap.indent(child.__str__(indent=indent + 1), indent * " ")
-            for child in self.children
-        ])
+    def __str__(self, indent=0):
+        ret_str = __print_ident__(self.name, self.description, indent)
+        ret_str += "\n"
+        ret_str += "\n".join(
+            [child.__str__(indent=indent + 1) for child in self.children])
         return ret_str
 
 
 @attr.s
-class FailOnError(GroupPolicy):
+class Task:
+    name: str = attr.ib()
+    description: str = attr.ib()
+    call: Callable[[], StepResult] = attr.ib()
+    owner: TaskGroup = attr.ib(default=None)
+
+    def __call__(self) -> StepResult:
+        """Perform actions that define this step implementation."""
+        delegate_fn = self.call
+        return delegate_fn()
+
+    def can_continue(self, task_result: StepResult) -> bool:
+        """Can execution of multiple child steps continue?"""
+        if self.owner:
+            return self.owner.can_continue(task_result)
+        else:
+            return True
+
+    def __str__(self, indent=0):
+        return __print_ident__(self.name, self.description, indent)
+
+
+@attr.s
+class Fail(TaskPolicy):
     def can_continue(self, task_result: StepResult) -> bool:
         res = task_result in [StepResult.OK, StepResult.CAN_CONTINUE]
         if not res:
@@ -68,139 +108,133 @@ class FailOnError(GroupPolicy):
 
 
 @attr.s
-class ContinueOnError(GroupPolicy):
+class Continue(TaskPolicy):
     def can_continue(self, task_result: StepResult) -> bool:
         self.state = task_result
         return True
 
+
+def __print_ident__(name: str, description: str, indent: int = 0) -> str:
+    return textwrap.indent(
+        "* {name}: {desc}".format(name=name, desc=description), indent * ' ')
+
+
+def catch_exceptions(task: 'Task'):
+    try:
+        result = task()
+    except (ProcessExecutionError, KeyboardInterrupt, OSError) as ex:
+        task.owner.on_error(result, ex)
+        result = StepResult.ERROR
+
+    return result
+
+
+@contextmanager
+def per_task_context(context, task: Task):
+    with ExitStack() as stack:
+        for mgr in context:
+            stack.enter_context(mgr(task))
+        yield task
+
+
+@contextmanager
+def global_context(context):
+    with ExitStack() as stack:
+        for mgr in context:
+            stack.enter_context(mgr)
+        yield
+
+
+def __merge_results__(results: List[StepResult],
+                      merge_results: Union[Iterable[StepResult], StepResult]
+                      ) -> Iterable[StepResult]:
+    if isinstance(merge_results, Iterable):
+        return list(itertools.chain(results, merge_results))
+
+    new_results: List[StepResult] = results
+    new_results.append(merge_results)
+
+    return new_results
+
+
 @attr.s
-class Task(NamedTaskEntity):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
+class TaskManager:
+    name: str = attr.ib()
+    description: str = attr.ib()
 
-        self.owner: 'GroupPolicy' = None
+    plan: TaskGroup = attr.ib()
+    task_context = attr.ib(default=attr.Factory(list))
+    global_context = attr.ib(default=attr.Factory(list))
 
-    def catch_exceptions(self, task: 'Task') -> StepResult:
-        try:
-            result = task()
-        except (ProcessExecutionError, KeyboardInterrupt, OSError) as ex:
-            task.on_error(result, ex)
-            result = StepResult.ERROR
+    def run(self):
+        res = StepResult.OK
+        results = []
 
-        return result
+        with global_context(self.global_context):
+            for task in self.plan.tasks():
+                if task.can_continue(res):
+                    with per_task_context(self.task_context,
+                                          task) as task_context:
+                        res = task_context()
+                results = __merge_results__(results, res)
+        return results
 
-    @abstractmethod
-    def on_error(self, task_result: StepResult, exception=None):
-        """What do we do with an error."""
+    def tasks(self):
+        all_tasks = [
+            child.tasks() for child in self.plan if hasattr(child, 'tasks')
+        ]
+        return list(itertools.chain(*all_tasks))
 
-    @abstractmethod
-    def on_result(self, task_result: StepResult):
-        """What do we do with a result."""
-
-    def can_continue(self, task_result: StepResult) -> bool:
-        """Can execution of multiple child steps continue?"""
-        if self.owner:
-            return self.owner.can_continue(task_result)
-        return True
-
-    def tasks(self) -> List[Union['Task', GroupPolicy]]:
-        return [self]
-
-    def __call__(self) -> StepResult:
-        """Perform actions that define this step implementation."""
+    def __call__(self) -> Iterable[StepResult]:
+        return self.run()
 
     def __str__(self, indent=0):
-        return textwrap.indent(
-            "* {name}: {desc}".format(name=self.name, desc=self.description),
-            indent * ' ')
+        return self.plan.__str__(indent=indent)
 
 
-@attr.s
-class Echo(Task):
+def fail_group(*tasks: RunnableTask) -> TaskGroup:
+    return TaskGroup("fail", "Fail on first error", tasks, Fail())
+
+
+def continue_group(*tasks: RunnableTask) -> TaskGroup:
+    return TaskGroup("continue", "Continue on any error", tasks, Continue())
+
+
+def echo(message: str) -> Task:
     """Print a message."""
-    message: str = attr.ib(kw_only=True)
 
-    def __call__(self) -> StepResult:
-        LOG.info(self.message)
+    def call_impl() -> StepResult:
+        LOG.info(message)
         return StepResult.OK
 
-    def __str__(self, indent=0):
-        return textwrap.indent(self.message, indent * ' ')
+    return Task("Echo", message, call_impl)
 
 
-@attr.s
-class Run(Task):
+def run_project(project: Project) -> Task:
     """Run a project."""
-    project: Project = attr.ib()
+    return Task("run", "Run a project", lambda: project.run())
 
-    def __call__(self) -> StepResult:
-        result = self.project.run()
-        return result
 
-@attr.s
-class Compile(Task):
+def compile_project(project: Project) -> Task:
     """Compile the project."""
-    project: Project = attr.ib()
+    return Task("compile", "Compile a project", lambda: project.compile())
 
-    def __call__(self) -> StepResult:
-        result = self.project.compile()
-        return result
 
-@attr.s
-class MakeBuildDir(Task):
+def make_builddir(project: Project) -> Task:
     """Create the build directory."""
-    project: Project = attr.ib()
 
-    def __call__(self) -> StepResult:
-        if not os.path.exists(self.project.builddir):
-            mkdir("-p", self.project.builddir)
+    def call_impl() -> StepResult:
+        if not os.path.exists(project.builddir):
+            mkdir("-p", project.builddir)
         return StepResult.OK
 
-@attr.s
-class Clean(Task):
-    """Clean the build directory."""
-    project: Project = attr.ib()
-    check_empty: bool = attr.ib(default=False)
+    return Task("mkdir", "create the build directory", call_impl)
 
-    @staticmethod
-    def clean_mountpoints(root: str):
-        """
-        Unmount any remaining mountpoints under :root.
 
-        Args:
-            root: All UnionFS-mountpoints under this directory will be
-                  unmounted.
-        """
-        import psutil
-        umount_paths = []
-        real_root = os.path.realpath(root)
-        for part in psutil.disk_partitions(all=True):
-            if os.path.commonpath([part.mountpoint, real_root]) == real_root:
-                if not part.fstype == "fuse.unionfs":
-                    LOG.error("NON-UnionFS mountpoint found under %s", root)
-                else:
-                    umount_paths.append(part.mountpoint)
-
-    def __call__(self) -> StepResult:
-        if not CFG['clean']:
-            LOG.warning("Clean disabled by config.")
-            return StepResult.CAN_CONTINUE
-        obj_builddir = os.path.abspath(self.project.builddir)
-        if os.path.exists(obj_builddir):
-            LOG.debug("Path %s exists", obj_builddir)
-            Clean.clean_mountpoints(obj_builddir)
-            if self.check_empty:
-                rmdir(obj_builddir, retcode=None)
-            else:
-                rm("-rf", obj_builddir)
-        else:
-            LOG.debug("Path %s did not exist anymore", obj_builddir)
-        return StepResult.OK
-
-@attr.s
-class CleanExtra(Task):
+def clean_extra() -> Task:
     """Cleans the extra directories."""
-    def __call__(self) -> StepResult:
+
+    def call_impl() -> StepResult:
         if not CFG['clean']:
             return StepResult.OK
 
@@ -210,113 +244,121 @@ class CleanExtra(Task):
                 rm("-r", p)
         return StepResult.OK
 
+    return Task("clean extra", "clean all external directories", call_impl)
 
 
-@attr.s
-class TaskManager(NamedTaskEntity):
-    plan: Union['GroupPolicy', 'Task'] = attr.ib()
+def clean_mountpoints(root: str):
+    """
+    Unmount any remaining mountpoints under :root.
 
-    def __merge_results__(self, results, merge_results):
-        if isinstance(merge_results, Iterable):
-            return list(itertools.chain(results, merge_results))
-
-        new_results = results
-        new_results.append(merge_results)
-        return new_results
-
-    def run(self):
-        res = StepResult.OK
-        results = []
-        for task in self.plan.tasks():
-            if task.can_continue(res):
-                with self.execution_context(task) as task_context:
-                    res = task_context()
-
-            results = self.__merge_results__(results, res)
-        return results
-
-    @contextmanager
-    def execution_context(self, task: Task):
-        log_ctx = LogTasks(task)
-
-        mgrs = [
-            log_ctx
-        ]
-
-        with ExitStack() as stack:
-            for mgr in mgrs:
-                stack.enter_context(mgr)
-            yield task
-
-    def __str__(self, indent=0):
-        ret_str = textwrap.indent(
-            "* {name}: {desc}\n".format(name=self.name,
-                                        desc=self.description), indent * ' ')
-        ret_str += self.plan.__str__(indent=indent+1)
-        return ret_str
-
-@attr.s
-class Experiment(TaskManager, Task):
-    """Run an experiment, wrapped in a db transaction."""
-    experiment = attr.ib()
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        name = self.experiment.name
-        self.plan = FailOnError([
-            Echo(message="Start experiment: {0}".format(name)),
-            self.plan,
-            Echo(message="Completed experiment: {0}".format(name))
-        ])
-
-
-    def begin_transaction(self):
-        experiment, session = db.persist_experiment(self.experiment)
-        if experiment.begin is None:
-            experiment.begin = datetime.now()
-        else:
-            experiment.begin = min(experiment.begin, datetime.now())
-        session.add(experiment)
-        try:
-            session.commit()
-        except sa.orm.exc.StaleDataError:
-            LOG.error("Transaction isolation level caused a StaleDataError")
-
-        # React to external signals
-        signals.handlers.register(Experiment.end_transaction, experiment,
-                                  session)
-
-        return experiment, session
-
-    @staticmethod
-    def end_transaction(experiment, session):
-        try:
-            if experiment.end is None:
-                experiment.end = datetime.now()
+    Args:
+        root: All UnionFS-mountpoints under this directory will be
+                unmounted.
+    """
+    import psutil
+    umount_paths = []
+    real_root = os.path.realpath(root)
+    for part in psutil.disk_partitions(all=True):
+        if os.path.commonpath([part.mountpoint, real_root]) == real_root:
+            if not part.fstype == "fuse.unionfs":
+                LOG.error("NON-UnionFS mountpoint found under %s", root)
             else:
-                experiment.end = max(experiment.end, datetime.now())
-            session.add(experiment)
-            session.commit()
-        except sa.exc.InvalidRequestError as inv_req:
-            LOG.error(inv_req)
+                umount_paths.append(part.mountpoint)
 
-    @contextmanager
-    def execution_context(self, task: Task) -> List[AbstractContextManager]:
-        experiment, session = self.begin_transaction()
-        yield task
-        self.end_transaction(experiment, session)
 
-    def __call__(self) -> StepResult:
-        results = self.run()
-        return results
+def clean(project: Project, check_empty: bool = False) -> Task:
+    """Clean the build directory."""
+
+    def call_impl():
+        if not CFG['clean']:
+            LOG.warning("Clean disabled by config.")
+            return StepResult.CAN_CONTINUE
+        obj_builddir = os.path.abspath(project.builddir)
+        if os.path.exists(obj_builddir):
+            LOG.debug("Path %s exists", obj_builddir)
+            clean_mountpoints(obj_builddir)
+            if check_empty:
+                rmdir(obj_builddir, retcode=None)
+            else:
+                rm("-rf", obj_builddir)
+        else:
+            LOG.debug("Path %s did not exist anymore", obj_builddir)
+        return StepResult.OK
+
+    return Task("clean", "clean the build directory.", call_impl)
+
+
+def begin_experiment(exp: Experiment):
+    db_exp, session = db.persist_experiment(exp)
+    if db_exp.begin is None:
+        db_exp.begin = datetime.now()
+    else:
+        db_exp.begin = min(db_exp.begin, datetime.now())
+    session.add(db_exp)
+    try:
+        session.commit()
+    except sa.orm.exc.StaleDataError:
+        LOG.error("Transaction isolation level caused a StaleDataError")
+
+    # React to external signals
+    signals.handlers.register(end_experiment, db_exp, session)
+
+    return db_exp, session
+
+
+def end_experiment(db_exp, session):
+    try:
+        if db_exp.end is None:
+            db_exp.end = datetime.now()
+        else:
+            db_exp.end = max(db_exp.end, datetime.now())
+        session.add(db_exp)
+        session.commit()
+    except sa.exc.InvalidRequestError as inv_req:
+        LOG.error(inv_req)
+
+
+def manage_experiment(experiment: Experiment, tasks: TaskGroup) -> TaskManager:
+    """Run an experiment, wrapped in a db transaction."""
+    name: str = experiment.name
+    exp_tasks = [
+        echo("Start experiment: {}".format(name)), tasks,
+        echo("Completed experiment: {}".format(name))
+    ]
+
+    task_group: TaskGroup = continue_group(*exp_tasks)
+    task_manager = TaskManager(
+        name="experiment",
+        description="run an experiment",
+        plan=task_group,
+        task_context=[LogTasks],
+        global_context=[ExperimentTransaction(experiment)])
+
+    return task_manager
 
 
 @attr.s
-class LogTasks(AbstractContextManager):
+class ExperimentTransaction:
+    experiment: Experiment = attr.ib()
+
+    db_exp = attr.ib(default=None)
+    db_session = attr.ib(default=None)
+
+    def __enter__(self):
+        self.db_exp, self.db_session = begin_experiment(self.experiment)
+
+    def __exit__(self, type, value, traceback):
+        end_experiment(self.db_exp, self.db_session)
+        return False
+
+
+@attr.s
+class LogTasks:
     task: Task = attr.ib()
 
     def __enter__(self):
-        LOG.info("\n%s - %s", self.task.name, self.task.description)
+        LOG.warning("\n%s - %s", self.task.name, self.task.description)
 
     def __exit__(self, type, value, traceback):
-        LOG.info("%s COMPLETE")
+        LOG.warning("%s COMPLETE", self.task.name)
+        return False

--- a/tests/test_tasks_v2.py
+++ b/tests/test_tasks_v2.py
@@ -1,0 +1,33 @@
+import unittest
+
+from benchbuild.tasks.actions import (ContinueOnError, Echo, FailOnError,
+                                      TaskManager, Experiment)
+from benchbuild.experiments.empty import Empty
+from benchbuild.utils.actions import StepResult
+
+
+class TestPlan(unittest.TestCase):
+
+    def test_plan(self):
+        plan = ContinueOnError([
+            FailOnError([Echo(message="Hello"),
+                         Echo(message="World")]),
+            FailOnError([Echo(message="Task v2"),
+                         Echo(message="Task Test")])
+        ])
+
+        tm = TaskManager(plan=plan)
+        results = tm.run()
+        self.assertEqual(
+            results,
+            [StepResult.OK] * 4)
+
+    def test_experiment(self):
+        exp = Experiment(experiment=Empty(),
+                         plan=ContinueOnError(
+                             [Echo(message="Hi from inside experiment")]))
+        tm = TaskManager(plan=exp)
+
+        results = tm.run()
+
+        self.assertEqual(results, [StepResult.OK] * 3)

--- a/tests/test_tasks_v2.py
+++ b/tests/test_tasks_v2.py
@@ -1,6 +1,9 @@
+"""
+Test the revised tasks API.
+"""
 import unittest
+import benchbuild.tasks as a
 
-from benchbuild.tasks import actions as a
 from benchbuild.experiments.empty import Empty
 from benchbuild.utils.actions import StepResult
 
@@ -17,7 +20,6 @@ class TestTaskGroups(unittest.TestCase):
         grp = a.fail_group(task)
 
         self.assertEqual(task.owner, grp)
-
 
     def test_plan(self):
         plan = a.continue_group(
@@ -50,9 +52,9 @@ class TestTaskGroups(unittest.TestCase):
         mgr = a.TaskManager("test fail on first", "", plan=plan)
         results = mgr.run()
 
-        self.assertEqual(len(results), 2,
-                         "Both actions executed")
-        self.assertEqual(results, [StepResult.ERROR, StepResult.ERROR], "no action executed succesfully")
+        self.assertEqual(len(results), 2, "Both actions executed")
+        self.assertEqual(results, [StepResult.ERROR, StepResult.ERROR],
+                         "no action executed succesfully")
 
     def test_continue_on_fail_2(self):
         fail_t = a.Task("fail", "", lambda: StepResult.ERROR)
@@ -74,4 +76,5 @@ class TestTaskGroups(unittest.TestCase):
 
         self.assertEqual(len(results), 3,
                          "2 out of 3 actions executed, but 3 returns")
-        self.assertEqual(results, [StepResult.OK, StepResult.ERROR, StepResult.ERROR])
+        self.assertEqual(results,
+                         [StepResult.OK, StepResult.ERROR, StepResult.ERROR])

--- a/tests/test_tasks_v2.py
+++ b/tests/test_tasks_v2.py
@@ -1,27 +1,77 @@
 import unittest
 
-from benchbuild.tasks.actions import (continue_group, echo, fail_group,
-                                      TaskManager, manage_experiment)
+from benchbuild.tasks import actions as a
 from benchbuild.experiments.empty import Empty
 from benchbuild.utils.actions import StepResult
 
 
-class TestPlan(unittest.TestCase):
+class TestTaskGroups(unittest.TestCase):
+    def test_has_owner_in_continue(self):
+        task = a.echo("")
+        grp = a.continue_group(task)
+
+        self.assertEqual(task.owner, grp)
+
+    def test_has_owner_in_fail(self):
+        task = a.echo("")
+        grp = a.fail_group(task)
+
+        self.assertEqual(task.owner, grp)
+
 
     def test_plan(self):
-        plan = continue_group(fail_group(echo("Hello"), echo("World")),
-                              fail_group(echo("Task v2"), echo("Task Test")))
+        plan = a.continue_group(
+            a.fail_group(a.echo("Hello"), a.echo("World")),
+            a.fail_group(a.echo("Task v2"), a.echo("Task Test")))
 
-        mgr = TaskManager(name="test", description="test", plan=plan)
+        mgr = a.TaskManager(name="test", description="test", plan=plan)
         results = mgr.run()
-        self.assertEqual(
-            results,
-            [StepResult.OK] * 4)
+        self.assertEqual(results, [StepResult.OK] * 4)
 
     def test_experiment(self):
-        exp = manage_experiment(
-            Empty(), fail_group(
-                echo("hi from inside experiment")))
+        exp = a.manage_experiment(
+            Empty(), a.fail_group(a.echo("hi from inside experiment")))
         results = exp.run()
 
         self.assertEqual(results, [StepResult.OK] * 3)
+
+    def test_continue_on_fail(self):
+        fail_t = a.Task("fail", "", lambda: StepResult.ERROR)
+        plan = a.continue_group(fail_t, a.echo("after fail"))
+        mgr = a.TaskManager("test continue on fail", "", plan=plan)
+        results = mgr.run()
+
+        self.assertEqual(len(results), 2, "Both actions have been executed")
+        self.assertEqual(results, [StepResult.ERROR, StepResult.OK])
+
+    def test_fail_on_first(self):
+        fail_t = a.Task("fail", "", lambda: StepResult.ERROR)
+        plan = a.fail_group(fail_t, a.echo("after fail"))
+        mgr = a.TaskManager("test fail on first", "", plan=plan)
+        results = mgr.run()
+
+        self.assertEqual(len(results), 2,
+                         "Both actions executed")
+        self.assertEqual(results, [StepResult.ERROR, StepResult.ERROR], "no action executed succesfully")
+
+    def test_continue_on_fail_2(self):
+        fail_t = a.Task("fail", "", lambda: StepResult.ERROR)
+        plan = a.continue_group(a.echo("before fail"), fail_t,
+                                a.echo("after fail"))
+        mgr = a.TaskManager("test continue on fail", "", plan=plan)
+        results = mgr.run()
+
+        self.assertEqual(len(results), 3, "All 3 actions have been executed")
+        self.assertEqual(results,
+                         [StepResult.OK, StepResult.ERROR, StepResult.OK])
+
+    def test_fail_on_first_2(self):
+        fail_t = a.Task("fail", "", lambda: StepResult.ERROR)
+        plan = a.fail_group(a.echo("before fail"), fail_t,
+                            a.echo("after fail"))
+        mgr = a.TaskManager("test continue on fail", "", plan=plan)
+        results = mgr.run()
+
+        self.assertEqual(len(results), 3,
+                         "2 out of 3 actions executed, but 3 returns")
+        self.assertEqual(results, [StepResult.OK, StepResult.ERROR, StepResult.ERROR])

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -58,10 +58,10 @@ class RunCompiler(WrapperTests):
 class RunStatic(WrapperTests):
     def test_create(self):
         with local.cwd(self.tmp_dir):
-            self.cmd = wrappers.wrap(self.tmp_script,
+            cmd = wrappers.wrap(self.tmp_script,
                                      EmptyProject(empty.Empty()))
             self.assertTrue(os.path.exists("{}.bin".format(self.tmp_script)))
-        self.assertTrue(os.path.exists(str(self.cmd)))
+        self.assertTrue(os.path.exists(str(cmd)))
 
 
 class RunDynamic(WrapperTests):


### PR DESCRIPTION
This pull request is just open to track progress on a new (more convenient) API for managing benchbuild tasks (former actions/steps).

The design is very simple. In the future we will deal with 3 separate types, a task, a task manager and a group policy.

A task is an almost 1-to-1 match for a former Step. A step requires a method to retreive all tasks from it 
(tasks()) and a __call__ method. Everything else is automatically extracted from the class __doc__ attribute and the class name.

A task manager is used to control the execution of multiple tasks. In general this will be the top-level entity that runs a set of experiments. It can also be used to define the former Experiment step, i.e., manage database sessions and parallelism.

The third type is kind of a mixin-class for tasks. GroupPolicies can be used to control a task manager. This matches the RequireAll / Any steps in the old implementation. They simply control the behavior in case of errors.

