### PR TITLE
Support for generic modules.

### DIFF
--- a/.pylint_init-hook.py
+++ b/.pylint_init-hook.py
@@ -1,0 +1,1 @@
+import benchbuild.utils.cmd

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,15 +1,10 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
-
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-#init-hook=
+init-hook="import imp, os; from pylint.config import find_pylintrc; imp.load_source('pylint_init_hook', os.path.join(os.path.dirname(find_pylintrc()), '.pylint_init-hook.py'))"
 
 # Add files or directories to the blacklist. They should be base names, not
-# paths.
-ignore=CVS,.git
+# paths
+ignore=CVS,.git,tmp,results,sql,.pylint_init-hook.py
 
 # Pickle collected data for later comparisons.
 persistent=no
@@ -28,7 +23,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-whitelist=_pygit2
 optimize-ast=no
 
 

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -1,7 +1,7 @@
 """Subcommand for project handling."""
 from plumbum import cli
 
-from benchbuild import project
+from benchbuild import module, project
 from benchbuild.cli.main import BenchBuild
 
 
@@ -29,6 +29,7 @@ class BBProjectView(cli.Application):
         self.groups = groups
 
     def main(self, *projects):
+        module.init()
         print_projects(project.populate(projects, self.groups))
 
 

--- a/benchbuild/cli/run.py
+++ b/benchbuild/cli/run.py
@@ -10,7 +10,7 @@ import time
 
 from plumbum import cli
 
-from benchbuild import experiment, experiments, project
+from benchbuild import experiment, experiments, module, project
 from benchbuild.cli.main import BenchBuild
 from benchbuild.settings import CFG
 from benchbuild.utils import actions, progress, tasks
@@ -90,6 +90,7 @@ class BenchBuildRun(cli.Application):
         experiment_names = self.experiment_names
         group_names = self.group_names
 
+        module.init()
         experiments.discover()
         all_exps = experiment.ExperimentRegistry.experiments
 

--- a/benchbuild/module.py
+++ b/benchbuild/module.py
@@ -1,0 +1,117 @@
+"""
+Module support for benchbuild.
+
+We provide a new module API for benchbuild. This allows for projects/experiments and extensions to live in a completly separate repository, reducing benchbuild's test surface.
+A module is essentially a folder containing a single file: .benchbuild-module.yml
+The format of the .yml is as follows:
+
+Example .benchbuild-module.yml
+```yaml
+modules:
+    - name: bzip2
+      main: benchbuild.projects.bzip2
+      settings: {}
+```
+
+The top-level element may contain a list of descriptors.
+Each descriptor element must contain a dict with at least the following entries:
+    name: <str> - The name of the plugin
+    main: <str> - The name of 
+In addition, you may provide an additional settings dict behind the
+'settings' key. This structure must follow benchbuild's configuration data
+structure and will be hooked into the default configuration at:
+```
+    CFG[<(projects|experiments|extensions)>][<name>]
+```
+
+All modules that should be included by benchbuild have to be added to the
+configuration at:
+```
+    CFG['plugins']['modules']
+```
+Each entry has to suffice the following format ``"<name>": "<path>"``
+Where <path> is a git repository, or an absolute path to a directory.
+"""
+import logging
+from typing import Dict, List, Tuple
+
+import attr
+import yaml
+from plumbum import local
+from plumbum.path.local import LocalPath
+
+from benchbuild.settings import CFG
+from benchbuild.utils.cmd import git
+from benchbuild.utils.settings import Configuration
+
+LOG = logging.getLogger(__name__)
+__MODULE_CONFIG__: str = '.benchbuild-module.yml'
+
+@attr.s()
+class Module:
+    name: str = attr.ib()
+    main: str = attr.ib()
+    settings: Configuration = attr.ib()
+
+
+def __create_modules__(module_config: str) -> List[Module]:
+    config = local.path(module_config)
+    if not (config.exists() or config.is_dir()):
+        LOG.error('Path "%s" does not exist', module_config)
+        return []
+
+    with open(config, 'r') as hdl:
+        loaded = yaml.safe_load(hdl)
+
+    LOG.debug("YAML in config: %s", repr(loaded))
+    assert 'modules' in loaded
+    mods = []
+    for mod in loaded['modules']:
+        assert 'name' in mod
+        assert 'main' in mod
+        _name = mod['name']
+        _main = mod['main']
+        _settings = mod['settings'] if 'settings' in mod else {}
+        mods.append(Module(_name, _main, Configuration('bb', node=_settings)))
+    return mods
+
+def __download__(name: str, source: str) -> str:
+    LOG.debug('Check, if we need to download: "%s"', name)
+    prefix = local.path(str(CFG['environment']))
+    def __exists__(mod_path: LocalPath) -> bool:
+        if mod_path.exists() and mod_path.is_dir():
+            LOG.debug('Module "%s" found in environment "%s"', name, mod_path)
+            return True
+        LOG.debug('Module "%s" not found in environment "%s"', name, mod_path)
+        return False
+
+    def __updated__(mod_path: LocalPath) -> bool:
+        git_dir = mod_path / ".git"
+        if __exists__(git_dir):
+            with local.cwd(mod_path):
+                git("reset", "--hard", "HEAD")
+                git("pull")
+
+    path = prefix / source
+    for path in [prefix / source, prefix / name]:
+        if __exists__(path):
+            if __updated__(path):
+                LOG.info("Repository was updated: %s", path)
+            return path / __MODULE_CONFIG__
+
+    LOG.debug('Downloading "%s" from: "%s"', name, source)
+    git("clone", source, path)
+    return path / __MODULE_CONFIG__
+
+
+def create_modules(modules: Dict[str, str]) -> List[Module]:
+    modules_to_load = []
+    for name, source in modules.items():
+        mod_location = __download__(name, source)
+        mods = __create_modules__(mod_location)
+        LOG.debug("Loaded module: %s", str(mods))
+        modules_to_load.extend(mods)
+    return modules_to_load
+
+def load_modules(modules: List[Module]):
+    ...

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -97,6 +97,10 @@ CFG = s.Configuration(
             "preoptimization.",
             "default":
             "no_preperation"
+        },
+        "environment": {
+            "desc": "Environment prefix directory for downloading modules.",
+            "default": s.ConfigPath(os.path.join(os.getcwd(), "env"))
         }
     })
 
@@ -288,6 +292,12 @@ CFG["plugins"] = {
         ],
         "desc":
         "The experiment plugins we know about."
+    },
+    "modules": {
+        "desc": "List of modules to fetch and autoload.",
+        "default": {
+            "bzip2": "https://gitlab.lairosiel.de/benchbuild/bzip2.git"
+        }
     },
     "projects": {
         "default": [

--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -160,10 +160,6 @@ def to_env_var(env_var: str, value) -> str:
     return ret_val
 
 
-class Configuration:
-    """Forward declaration."""
-
-
 class Configuration():
     """
     Dictionary-like data structure to contain all configuration variables.
@@ -180,7 +176,11 @@ class Configuration():
     The configuration can be stored/loaded as YAML.
     """
 
-    def __init__(self, parent_key: str, node=None, parent=None, init=True):
+    def __init__(self,
+                 parent_key: str,
+                 node=None,
+                 parent: 'Configuration' = None,
+                 init: bool = True):
         self.parent = parent
         self.parent_key = parent_key
         self.node = node if node is not None else {}
@@ -290,7 +290,7 @@ class Configuration():
             return validate(self.node['value'])
         return self
 
-    def __getitem__(self, key) -> Configuration:
+    def __getitem__(self, key) -> 'Configuration':
         if key not in self.node:
             warnings.warn(
                 "Access to non-existing config element: {0}".format(key),
@@ -308,7 +308,7 @@ class Configuration():
             else:
                 self.node[key] = {'value': val}
 
-    def __iadd__(self, rhs) -> Configuration:
+    def __iadd__(self, rhs) -> 'Configuration':
         """Append a value to a list value."""
         if not self.has_value():
             raise TypeError("Inner configuration node does not support +=.")

--- a/benchbuild/utils/templates/run_compiler.py.inc
+++ b/benchbuild/utils/templates/run_compiler.py.inc
@@ -5,10 +5,14 @@ import sys
 
 from plumbum import TEE, local
 
+from benchbuild import module
 from benchbuild.utils import log
 from benchbuild.utils.db import persist_project
 from benchbuild.utils.run import exit_code_from_run_infos
 from benchbuild.utils.wrapping import load
+
+# FIXME: Find a way to specifically load the requested module, instead of all.
+module.init()
 
 PROJECT = load("{{ project_file }}")
 COMPILER = load("{{ cc_f }}")

--- a/benchbuild/utils/templates/run_dynamic.py.inc
+++ b/benchbuild/utils/templates/run_dynamic.py.inc
@@ -6,10 +6,14 @@ import sys
 
 from plumbum import TEE, local
 
+from benchbuild import module
 from benchbuild.utils import log
 from benchbuild.utils.db import persist_project
 from benchbuild.utils.run import exit_code_from_run_infos
 from benchbuild.utils.wrapping import load
+
+# FIXME: Find a way to specifically load the requested module, instead of all.
+module.init()
 
 PROJECT = load("{{ project_file }}")
 FILTER_EXPRESSIONS = {{name_filters}}

--- a/benchbuild/utils/templates/run_static.py.inc
+++ b/benchbuild/utils/templates/run_static.py.inc
@@ -4,9 +4,13 @@ import sys
 
 from plumbum import TEE, local
 
+from benchbuild import module
 from benchbuild.utils import log
 from benchbuild.utils.run import exit_code_from_run_infos
 from benchbuild.utils.wrapping import load
+
+# FIXME: Find a way to specifically load the requested module, instead of all.
+module.init()
 
 PROJECT = load("{{ project_file }}")
 

--- a/benchbuild/utils/wrapping.py
+++ b/benchbuild/utils/wrapping.py
@@ -274,7 +274,7 @@ def persist(id_obj, filename=None, suffix=None):
         filename = "{obj_id}{suffix}".format(obj_id=ident, suffix=suffix)
 
     with open(filename, 'wb') as obj_file:
-        dill.dump(id_obj, obj_file)
+        dill.dump(id_obj, obj_file, recurse=True)
     return os.path.abspath(filename)
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "pandas>=0.20.3",
         "psutil>=4.0.0",
         "sqlalchemy-migrate",
+        "pygit2>=0.28.2",
         "pygtrie>=2.2",
         "pyparsing>=2.2",
         "PyYAML~=5.1",

--- a/tests/modules/test_module_load.py
+++ b/tests/modules/test_module_load.py
@@ -1,0 +1,11 @@
+import pytest
+import benchbuild.module as mods
+from benchbuild.settings import CFG
+
+@pytest.fixture
+def modules():
+    yield {'bzip2': 'https://gitlab.lairosiel.de/benchbuild/bzip2.git'}
+
+def test_module_discovery(modules):
+    loaded = mods.create_modules(modules)
+    assert len(loaded) == 1

--- a/tests/modules/test_module_load.py
+++ b/tests/modules/test_module_load.py
@@ -1,6 +1,7 @@
+import importlib
 import pytest
+import sys
 import benchbuild.module as mods
-from benchbuild.settings import CFG
 
 @pytest.fixture
 def modules():
@@ -8,4 +9,11 @@ def modules():
 
 def test_module_discovery(modules):
     loaded = mods.create_modules(modules)
-    assert len(loaded) == 1
+    assert len(loaded) == len(modules)
+
+def test_init_environment(modules):
+    discovered = mods.create_modules(modules)
+    loaded = mods.init_environment(discovered)
+    assert len(loaded) == len(modules)
+    for m in loaded:
+        assert m.__class__ == importlib.types.ModuleType


### PR DESCRIPTION
This is the initial prototype for module support in benchbuild. The
finished feature will unify projects/experiments and extensions in one
abstraction.

Benchbuild comes with a pre-defined set of projects from different
domains. These often require test artifacts to be present during
testing. Up to now, these artifacts have been stored in a sperate
repository only to be accesses by magic paths to benchbuild's 'test-dir'
configuration variable.

Modules will remove that invisible dependency by extracting anything
that extends benchbuild into separate repositories, loaded on demand.
This way we can keep the footprint of a benchbuild distribution small
and still provide a lot of flexibility.

Furthermore, this will ease the implementation of unittests. We can now
extract them out of benchbuild's main test path and avoid running huge
test-loads ont he CI system, even if nothing changes that much in the
project area.