### PR TITLE
Slurm: Changes project string separator to '-'

### DIFF
--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -52,7 +52,7 @@ def __expand_project_versions__(experiment: Experiment) -> Iterable[str]:
     for _, project_type in project_types.items():
         for version in project_type.versions():
             project = project_type(experiment, version=version)
-            expanded.append("{name}/{group}@{version}".format(
+            expanded.append("{name}-{group}@{version}".format(
                 name=project.name,
                 group=project.group,
                 version=project.version))

--- a/benchbuild/utils/templates/slurm.sh.inc
+++ b/benchbuild/utils/templates/slurm.sh.inc
@@ -83,4 +83,5 @@ EOF
 # End of cleanup cluster node
 
 # SLURM Command
+_project=$(echo ${_project} | sed -e "s/-/\//")
 {{ node_command }}


### PR DESCRIPTION
The old separator '/' was interpreted by the generated slurm.sh as a path separator and causing errors.