### PR TITLE
Slurm: Call sample() during version expansion.

### DIFF
--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -50,7 +50,7 @@ def __expand_project_versions__(experiment: Experiment) -> Iterable[str]:
     expanded = []
 
     for _, project_type in project_types.items():
-        for version in project_type.versions():
+        for version in experiment.sample(project_type, project_type.versions()):
             project = project_type(experiment, version=version)
             expanded.append("{name}-{group}@{version}".format(
                 name=project.name,


### PR DESCRIPTION
The slurm script generator generates jobs for all versions of a project, even though some versions might be skipped by an experiment's `sample()` method.
This can cause quite some "empty" jobs, e.g., in the case of re-evaluating only failed versions.

This PR fixes this problem by calling the experiment's `sample()` when expanding the versions during slurm script generation.

Note that `versions/full` should be set to `true` in the config file as otherwise, only one slurm job will be generated.