### PR TITLE
Fixes flock around `git worktree add`.

### DIFF
--- a/benchbuild/utils/download.py
+++ b/benchbuild/utils/download.py
@@ -239,7 +239,7 @@ def Git(repository, directory, rev=None, prefix=None, shallow_clone=True):
 
     src_dir = local.path(repository_loc) / directory
     tgt_dir = local.path(local.cwd) / directory
-    lock_f = local.path(local.cwd / directory + '.lock')
+    lock_f = local.path(repository_loc + directory + '.lock')
 
     extra_param = []
     if shallow_clone:


### PR DESCRIPTION
The lock around the call to `git worktree add` should prevent race conditions when processing many jobs in parallel (e.g., via slurm). However, this lock currently depends on the `cwd` of the specific job, which is unique for each job. Hence, the lock has no effect.

This PR fixes this issue by using the (common) `repository_dir` for the file lock instead.