### PR TITLE
Changes import warning level to debug

### DIFF
--- a/benchbuild/utils/__init__.py
+++ b/benchbuild/utils/__init__.py
@@ -80,7 +80,7 @@ class CommandAlias(ModuleType):
                 return alias_cmd
             except AttributeError:
                 pass
-        LOG.warning("'%s' cannot be found. Import failed.", command)
+        LOG.debug("'%s' cannot be found. Import failed.", command)
         return ERROR
 
     def __getitem__(self, command):


### PR DESCRIPTION
Reporting missing tool that are imported only leads to problems when executed but the warning is shown at parse-time. Therefore, we change the warning level to debug, to reduce the warning overflow.