### PR TITLE
Fixes log_dir generation for slurm

### DIFF
--- a/benchbuild/utils/templates/slurm.sh.inc
+++ b/benchbuild/utils/templates/slurm.sh.inc
@@ -26,7 +26,6 @@ projects=(
 # End of list of available projects
 _project="${projects[$SLURM_ARRAY_TASK_ID]}"
 
-mkdir -p $(dirname {{ log }})
 exec 1> {{ log }}-$_project
 exec 2>&1
 


### PR DESCRIPTION
The BB config does not always end paths with '/', therefore,
os.path.dirname falsely resolves the log dir to the parent. This rewrite
uses the new python pathlib, which does not have this behavior.
Furthermore, we now precheck if the specified dir exists on the BB side
and create it if not.  Should the user have supplied a wrong path, e.g.,
a file, a warning is generated and we default to a folder name
corresponding to the files stem.