### PR TITLE
Adds jobs lookup function

### DIFF
--- a/benchbuild/container.py
+++ b/benchbuild/container.py
@@ -16,6 +16,7 @@ from benchbuild.settings import CFG
 from benchbuild.utils import bootstrap, container, download, log, run, uchroot
 from benchbuild.utils import user_interface as ui
 from benchbuild.utils.cmd import bash, mkdir, mv, rm, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 LOG = logging.getLogger(__name__)
 
@@ -234,7 +235,7 @@ class SetupPolyJITGentooStrategy(ContainerStrategy):
 
             packages = \
                 CFG["container"]["strategy"]["polyjit"]["packages"].value
-            with local.env(MAKEOPTS="-j{0}".format(int(CFG["jobs"]))):
+            with local.env(MAKEOPTS="-j{0}".format(get_number_of_jobs(CFG))):
                 if want_sync:
                     LOG.debug("Synchronizing portage.")
                     run.run(emerge_in_chroot["--sync"])

--- a/benchbuild/extensions/run.py
+++ b/benchbuild/extensions/run.py
@@ -6,6 +6,7 @@ from plumbum import local
 
 from benchbuild.extensions import base
 from benchbuild.utils import db, run
+from benchbuild.utils.settings import get_number_of_jobs
 
 LOG = logging.getLogger(__name__)
 
@@ -81,10 +82,10 @@ class SetThreadLimit(base.Extension):
 
         config = self.config
         if config is not None and 'jobs' in config.keys():
-            jobs = config['jobs']
+            jobs = get_number_of_jobs(config)
         else:
             LOG.warning("Parameter 'config' was unusable, using defaults")
-            jobs = int(CFG["jobs"])
+            jobs = get_number_of_jobs(CFG)
 
         ret = None
         with local.env(OMP_NUM_THREADS=str(jobs)):

--- a/benchbuild/projects/benchbuild/ffmpeg.py
+++ b/benchbuild/projects/benchbuild/ffmpeg.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import make, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_wget({
@@ -40,4 +41,4 @@ class LibAV(project.Project):
                 "--disable-shared", "--cc=" + str(clang), "--extra-ldflags=" +
                 " ".join(self.ldflags), "--samples=" + self.fate_dir])
             run.run(make["clean"])
-            run.run(make["-j{0}".format(str(CFG["jobs"])), "all"])
+            run.run(make["-j{0}".format(str(get_number_of_jobs(CFG))), "all"])

--- a/benchbuild/projects/benchbuild/gzip.py
+++ b/benchbuild/projects/benchbuild/gzip.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import cp, make, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_wget({"1.6": "http://ftpmirror.gnu.org/gzip/gzip-1.6.tar.xz"})
@@ -52,4 +53,4 @@ class Gzip(project.Project):
             with local.env(CC=str(clang)):
                 run.run(configure["--disable-dependency-tracking",
                                   "--disable-silent-rules", "--with-gnu-ld"])
-            run.run(make["-j" + str(CFG["jobs"]), "clean", "all"])
+            run.run(make["-j" + str(get_number_of_jobs(CFG)), "clean", "all"])

--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -5,6 +5,7 @@ from plumbum import local
 from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
+from benchbuild.utils.settings import get_number_of_jobs
 from benchbuild.utils.cmd import make, mkdir, tar
 
 
@@ -56,7 +57,7 @@ class SpiderMonkey(project.Project):
 
         mozjs_obj_dir = mozjs_src_dir / "obj"
         with local.cwd(mozjs_obj_dir):
-            run.run(make["-j", str(CFG["jobs"])])
+            run.run(make["-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         mozjs_obj_dir = local.path("mozjs-0.0.0") / "js" / "src" / "obj"

--- a/benchbuild/projects/benchbuild/lapack.py
+++ b/benchbuild/projects/benchbuild/lapack.py
@@ -6,6 +6,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import make, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_git("https://github.com/xianyi/OpenBLAS", limit=5)
@@ -66,10 +67,10 @@ class Lapack(project.Project):
                 ]
                 makefile.writelines(content)
 
-            run.run(make["-j", CFG["jobs"], "f2clib", "blaslib"])
+            run.run(make["-j", get_number_of_jobs(CFG), "f2clib", "blaslib"])
             with local.cwd(local.path("BLAS") / "TESTING"):
-                run.run(make["-j", CFG["jobs"], "-f", "Makeblat2"])
-                run.run(make["-j", CFG["jobs"], "-f", "Makeblat3"])
+                run.run(make["-j", get_number_of_jobs(CFG), "-f", "Makeblat2"])
+                run.run(make["-j", get_number_of_jobs(CFG), "-f", "Makeblat3"])
 
     def run_tests(self, runner):
         unpack_dir = local.path("CLAPACK-{0}".format(self.version))

--- a/benchbuild/projects/benchbuild/mcrypt.py
+++ b/benchbuild/projects/benchbuild/mcrypt.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, path, run, wrapping
 from benchbuild.utils.cmd import make, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_wget({
@@ -54,14 +55,14 @@ class MCrypt(project.Project):
             configure = local["./configure"]
             with local.env(CC=_cc, CXX=_cxx):
                 run.run(configure["--prefix=" + builddir])
-                run.run(make["-j", CFG["jobs"], "install"])
+                run.run(make["-j", get_number_of_jobs(CFG), "install"])
 
         # Builder libmcrypt dependency
         with local.cwd(libmcrypt_dir):
             configure = local["./configure"]
             with local.env(CC=_cc, CXX=_cxx):
                 run.run(configure["--prefix=" + builddir])
-                run.run(make["-j", CFG["jobs"], "install"])
+                run.run(make["-j", get_number_of_jobs(CFG), "install"])
 
         with local.cwd(mcrypt_dir):
             configure = local["./configure"]
@@ -79,9 +80,9 @@ class MCrypt(project.Project):
             with local.env(**env):
                 run.run(configure["--disable-dependency-tracking",
                                   "--enable-static", "--disable-shared",
-                                  "--with-libmcrypt=" +
-                                  builddir, "--with-libmhash=" + builddir])
-            run.run(make["-j", CFG["jobs"]])
+                                  "--with-libmcrypt=" + builddir,
+                                  "--with-libmhash=" + builddir])
+            run.run(make["-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         mcrypt_dir = local.path(self.builddir) / "mcrypt-2.6.8"

--- a/benchbuild/projects/benchbuild/rasdaman.py
+++ b/benchbuild/projects/benchbuild/rasdaman.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run
 from benchbuild.utils.cmd import autoreconf, make
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_git('git://rasdaman.org/rasdaman.git', limit=5)
@@ -35,7 +36,7 @@ class Rasdaman(project.Project):
                 run.run(configure["--with-pic", "--enable-static",
                                   "--disable-debug", "--with-gnu-ld",
                                   "--without-ld-shared", "--without-libtool"])
-                run.run(make["-j", CFG["jobs"]])
+                run.run(make["-j", get_number_of_jobs(CFG)])
 
         with local.cwd(rasdaman_dir):
             autoreconf("-i")
@@ -46,7 +47,7 @@ class Rasdaman(project.Project):
                                   "--enable-benchmark", "--with-static-libs",
                                   "--disable-java", "--with-pic",
                                   "--disable-debug", "--without-docs"])
-            run.run(make["clean", "all", "-j", CFG["jobs"]])
+            run.run(make["clean", "all", "-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         import logging

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import make, ruby, tar
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_wget({
@@ -27,9 +28,9 @@ class Ruby(project.Project):
         with local.cwd(unpack_dir):
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 configure = local["./configure"]
-                run.run(
-                    configure["--with-static-linked-ext", "--disable-shared"])
-            run.run(make["-j", CFG["jobs"]])
+                run.run(configure["--with-static-linked-ext",
+                                  "--disable-shared"])
+            run.run(make["-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         unpack_dir = local.path('ruby-{0}'.format(self.version))

--- a/benchbuild/projects/benchbuild/sdcc.py
+++ b/benchbuild/projects/benchbuild/sdcc.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import make
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 class SDCC(project.Project):
@@ -26,7 +27,7 @@ class SDCC(project.Project):
                 run.run(configure["--without-ccache", "--disable-pic14-port",
                                   "--disable-pic16-port"])
 
-            run.run(make["-j", CFG["jobs"]])
+            run.run(make["-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         sdcc = wrapping.wrap(self.run_f, self)

--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -4,6 +4,7 @@ from benchbuild import project
 from benchbuild.settings import CFG
 from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import cp, make
+from benchbuild.utils.settings import get_number_of_jobs
 
 
 @download.with_git(
@@ -39,7 +40,7 @@ class X264(project.Project):
                 run.run(configure["--disable-thread", "--disable-opencl",
                                   "--enable-pic"])
 
-            run.run(make["clean", "all", "-j", CFG["jobs"]])
+            run.run(make["clean", "all", "-j", get_number_of_jobs(CFG)])
 
     def run_tests(self, runner):
         x264 = wrapping.wrap(local.path(self.src_file) / "x264", self)

--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -85,6 +85,19 @@ def available_cpu_count() -> int:
     raise Exception('Can not determine number of CPUs on this system')
 
 
+def current_available_threads() -> int:
+    """Returns the number of currently available threads for BB."""
+    return len(os.sched_getaffinity(0))
+
+
+def get_number_of_jobs(config: 'Configuration') -> int:
+    """Returns the number of jobs set in the config."""
+    jobs_configured = int(config["jobs"])
+    if jobs_configured == 0:
+        return current_available_threads()
+    return jobs_configured
+
+
 class InvalidConfigKey(RuntimeWarning):
     """Warn, if you access a non-existing key benchbuild's configuration."""
 


### PR DESCRIPTION
The amount of jobs that are available can now be determined by a getter
functions. This allows us to specify 0 in the config to hint benchbuild
to determine the number of available threads on the fly.