### PR TITLE
refactor: replace utils.run.run [breaks: <=4.0.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ class BZip(AutoPortage):
   NAME = "app-arch"
   DOMAIN = "bzip2"
 
-  def run_tests(self, run):
+  def run_tests(self):
     """Add your custom test routines here."""
 ```
 

--- a/benchbuild/container.py
+++ b/benchbuild/container.py
@@ -223,11 +223,13 @@ class SetupPolyJITGentooStrategy(ContainerStrategy):
             gentoo.configure_portage()
 
             sed_in_chroot = uchroot.uchroot()["/bin/sed"]
+            sed_in_chroot = run.watch(sed_in_chroot)
             emerge_in_chroot = uchroot.uchroot()["/usr/bin/emerge"]
+            emerge_in_chroot = run.watch(emerge_in_chroot)
             has_pkg = uchroot.uchroot()["/usr/bin/qlist", "-I"]
 
-            run.run(sed_in_chroot["-i", '/CC=/d', "/etc/portage/make.conf"])
-            run.run(sed_in_chroot["-i", '/CXX=/d', "/etc/portage/make.conf"])
+            sed_in_chroot("-i", '/CC=/d', "/etc/portage/make.conf")
+            sed_in_chroot("-i", '/CXX=/d', "/etc/portage/make.conf")
 
             want_sync = bool(CFG["container"]["strategy"]["polyjit"]["sync"])
             want_upgrade = bool(
@@ -238,17 +240,17 @@ class SetupPolyJITGentooStrategy(ContainerStrategy):
             with local.env(MAKEOPTS="-j{0}".format(get_number_of_jobs(CFG))):
                 if want_sync:
                     LOG.debug("Synchronizing portage.")
-                    run.run(emerge_in_chroot["--sync"])
+                    emerge_in_chroot("--sync")
                 if want_upgrade:
                     LOG.debug("Upgrading world.")
-                    run.run(emerge_in_chroot["--autounmask-only=y", "-uUDN",
-                                             "--with-bdeps=y", "@world"])
+                    emerge_in_chroot("--autounmask-only=y", "-uUDN",
+                                     "--with-bdeps=y", "@world")
                 for pkg in packages:
                     if has_pkg[pkg["name"]] & TF:
                         continue
                     env = pkg["env"]
                     with local.env(**env):
-                        run.run(emerge_in_chroot[pkg["name"]])
+                        emerge_in_chroot(pkg["name"])
 
             gentoo.setup_benchbuild()
 

--- a/benchbuild/extensions/log.py
+++ b/benchbuild/extensions/log.py
@@ -34,12 +34,13 @@ class LogAdditionals(base.Extension):
             return None
 
         res = self.call_next(*args, **kwargs)
+        cat_ = run.watch(cat)
 
         for ext in self.next_extensions:
             if issubclass(ext.__class__, (LogTrackingMixin)):
                 for log in ext.logs:
                     LOG.debug("Dumping content of '%s'.", log)
-                    run.run(cat[log])
+                    cat_(log)
                     LOG.debug("Dumping content of '%s' complete.", log)
 
         return res

--- a/benchbuild/extensions/log.py
+++ b/benchbuild/extensions/log.py
@@ -34,13 +34,13 @@ class LogAdditionals(base.Extension):
             return None
 
         res = self.call_next(*args, **kwargs)
-        cat_ = run.watch(cat)
+        _cat = run.watch(cat)
 
         for ext in self.next_extensions:
             if issubclass(ext.__class__, (LogTrackingMixin)):
                 for log in ext.logs:
                     LOG.debug("Dumping content of '%s'.", log)
-                    cat_(log)
+                    _cat(log)
                     LOG.debug("Dumping content of '%s' complete.", log)
 
         return res

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -259,8 +259,8 @@ class Project(metaclass=ProjectDecorator):
             run: A function that takes the run command.
         """
         exp = wrapping.wrap(self.run_f, self)
-        exp = run.watch(exp)
-        exp()
+        _exp = run.watch(exp)
+        _exp()
 
     def run(self):
         """Run the tests of this project.

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -248,7 +248,7 @@ class Project(metaclass=ProjectDecorator):
     def __attrs_post_init__(self):
         db.persist_project(self)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         """
         Run the tests of this project.
 
@@ -259,7 +259,8 @@ class Project(metaclass=ProjectDecorator):
             run: A function that takes the run command.
         """
         exp = wrapping.wrap(self.run_f, self)
-        runner(exp)
+        exp = run.watch(exp)
+        exp()
 
     def run(self):
         """Run the tests of this project.
@@ -283,7 +284,7 @@ class Project(metaclass=ProjectDecorator):
         signals.handlers.register(fail_run_group, group, session)
 
         try:
-            self.run_tests(run.run)
+            self.run_tests()
             end_run_group(group, session)
         except ProcessExecutionError:
             fail_run_group(group, session)

--- a/benchbuild/projects/apollo/rodinia.py
+++ b/benchbuild/projects/apollo/rodinia.py
@@ -42,13 +42,14 @@ class RodiniaGroup(project.Project):
                     _cc = _cc[config_flags]
                 _cc = _cc[srcfiles]
                 _cc = _cc["-o", outfile]
-                run.run(_cc)
+                _cc = run.watch(_cc)
+                _cc()
 
     @staticmethod
     def select_compiler(c_compiler, _):
         return c_compiler
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('rodinia_{0}'.format(self.version))
         in_src_dir = unpack_dir / self.config['dir']
 
@@ -56,7 +57,8 @@ class RodiniaGroup(project.Project):
             wrapping.wrap(in_src_dir / outfile, self)
 
         with local.cwd(in_src_dir):
-            runner(sh['./run'])
+            sh_ = run.watch(sh)
+            sh_('./run')
 
 
 class Backprop(RodiniaGroup):

--- a/benchbuild/projects/apollo/scimark.py
+++ b/benchbuild/projects/apollo/scimark.py
@@ -22,10 +22,10 @@ class SciMark(Project):
         self.download()
         unzip(local.cwd / self.src_file)
         clang = cc(self)
-        clang = run.watch(clang)
-        make("CC=" + str(clang), "scimark2")
+        _clang = run.watch(clang)
+        make("CC=" + str(_clang), "scimark2")
 
     def run_tests(self):
         scimark2 = wrap(local.path('scimark2'), self)
-        scimark2 = run.watch(scimark2)
-        scimark2()
+        _scimark2 = run.watch(scimark2)
+        _scimark2()

--- a/benchbuild/projects/apollo/scimark.py
+++ b/benchbuild/projects/apollo/scimark.py
@@ -1,10 +1,10 @@
 from plumbum import local
 
 from benchbuild.project import Project
+from benchbuild.utils import run
 from benchbuild.utils.cmd import make, unzip
 from benchbuild.utils.compiler import cc
 from benchbuild.utils.download import with_wget
-from benchbuild.utils.run import run
 from benchbuild.utils.wrapping import wrap
 
 
@@ -22,8 +22,10 @@ class SciMark(Project):
         self.download()
         unzip(local.cwd / self.src_file)
         clang = cc(self)
-        run(make["CC=" + str(clang), "scimark2"])
+        clang = run.watch(clang)
+        make("CC=" + str(clang), "scimark2")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         scimark2 = wrap(local.path('scimark2'), self)
-        runner(scimark2)
+        scimark2 = run.watch(scimark2)
+        scimark2()

--- a/benchbuild/projects/benchbuild/bots.py
+++ b/benchbuild/projects/benchbuild/bots.py
@@ -90,22 +90,22 @@ class BOTSGroup(project.Project):
             config.writelines(lines)
         mkdir(local.path(self.src_file) / "bin")
         with local.cwd(self.src_file):
-            make_ = run.watch(make)
-            make_("-C", self.path_dict[self.name])
+            _make = run.watch(make)
+            _make("-C", self.path_dict[self.name])
 
     def run_tests(self):
         binary_name = "{name}.benchbuild.serial".format(name=self.name)
         binary_path = local.path(self.src_file) / "bin" / binary_name
         exp = wrapping.wrap(binary_path, self)
-        exp = run.watch(exp)
+        _exp = run.watch(exp)
 
         if self.name in self.input_dict:
             for test_input in self.input_dict[self.name]:
                 input_file = local.path(
                     self.src_file) / "inputs" / self.name / test_input
-                exp("-f", input_file)
+                _exp("-f", input_file)
         else:
-            exp()
+            _exp()
 
 
 class Alignment(BOTSGroup):

--- a/benchbuild/projects/benchbuild/bots.py
+++ b/benchbuild/projects/benchbuild/bots.py
@@ -90,20 +90,22 @@ class BOTSGroup(project.Project):
             config.writelines(lines)
         mkdir(local.path(self.src_file) / "bin")
         with local.cwd(self.src_file):
-            run.run(make["-C", self.path_dict[self.name]])
+            make_ = run.watch(make)
+            make_("-C", self.path_dict[self.name])
 
-    def run_tests(self, runner):
+    def run_tests(self):
         binary_name = "{name}.benchbuild.serial".format(name=self.name)
         binary_path = local.path(self.src_file) / "bin" / binary_name
         exp = wrapping.wrap(binary_path, self)
+        exp = run.watch(exp)
 
         if self.name in self.input_dict:
             for test_input in self.input_dict[self.name]:
                 input_file = local.path(
                     self.src_file) / "inputs" / self.name / test_input
-                runner(exp["-f", input_file])
+                exp("-f", input_file)
         else:
-            runner(exp)
+            exp()
 
 
 class Alignment(BOTSGroup):

--- a/benchbuild/projects/benchbuild/bzip2.py
+++ b/benchbuild/projects/benchbuild/bzip2.py
@@ -27,21 +27,23 @@ class Bzip2(project.Project):
 
         clang = compiler.cc(self)
         with local.cwd(self.src_file):
-            run.run(make["CFLAGS=-O3", "CC=" + str(clang), "clean", "bzip2"])
+            make_ = run.watch(make)
+            make_("CFLAGS=-O3", "CC=" + str(clang), "clean", "bzip2")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         bzip2 = wrapping.wrap(local.path(self.src_file) / "bzip2", self)
+        bzip2 = run.watch(bzip2)
 
         # Compress
-        runner(bzip2["-f", "-z", "-k", "--best", "text.html"])
-        runner(bzip2["-f", "-z", "-k", "--best", "chicken.jpg"])
-        runner(bzip2["-f", "-z", "-k", "--best", "control"])
-        runner(bzip2["-f", "-z", "-k", "--best", "input.source"])
-        runner(bzip2["-f", "-z", "-k", "--best", "liberty.jpg"])
+        bzip2("-f", "-z", "-k", "--best", "text.html")
+        bzip2("-f", "-z", "-k", "--best", "chicken.jpg")
+        bzip2("-f", "-z", "-k", "--best", "control")
+        bzip2("-f", "-z", "-k", "--best", "input.source")
+        bzip2("-f", "-z", "-k", "--best", "liberty.jpg")
 
         # Decompress
-        runner(bzip2["-f", "-k", "--decompress", "text.html.bz2"])
-        runner(bzip2["-f", "-k", "--decompress", "chicken.jpg.bz2"])
-        runner(bzip2["-f", "-k", "--decompress", "control.bz2"])
-        runner(bzip2["-f", "-k", "--decompress", "input.source.bz2"])
-        runner(bzip2["-f", "-k", "--decompress", "liberty.jpg.bz2"])
+        bzip2("-f", "-k", "--decompress", "text.html.bz2")
+        bzip2("-f", "-k", "--decompress", "chicken.jpg.bz2")
+        bzip2("-f", "-k", "--decompress", "control.bz2")
+        bzip2("-f", "-k", "--decompress", "input.source.bz2")
+        bzip2("-f", "-k", "--decompress", "liberty.jpg.bz2")

--- a/benchbuild/projects/benchbuild/bzip2.py
+++ b/benchbuild/projects/benchbuild/bzip2.py
@@ -32,18 +32,18 @@ class Bzip2(project.Project):
 
     def run_tests(self):
         bzip2 = wrapping.wrap(local.path(self.src_file) / "bzip2", self)
-        bzip2 = run.watch(bzip2)
+        _bzip2 = run.watch(bzip2)
 
         # Compress
-        bzip2("-f", "-z", "-k", "--best", "text.html")
-        bzip2("-f", "-z", "-k", "--best", "chicken.jpg")
-        bzip2("-f", "-z", "-k", "--best", "control")
-        bzip2("-f", "-z", "-k", "--best", "input.source")
-        bzip2("-f", "-z", "-k", "--best", "liberty.jpg")
+        _bzip2("-f", "-z", "-k", "--best", "text.html")
+        _bzip2("-f", "-z", "-k", "--best", "chicken.jpg")
+        _bzip2("-f", "-z", "-k", "--best", "control")
+        _bzip2("-f", "-z", "-k", "--best", "input.source")
+        _bzip2("-f", "-z", "-k", "--best", "liberty.jpg")
 
         # Decompress
-        bzip2("-f", "-k", "--decompress", "text.html.bz2")
-        bzip2("-f", "-k", "--decompress", "chicken.jpg.bz2")
-        bzip2("-f", "-k", "--decompress", "control.bz2")
-        bzip2("-f", "-k", "--decompress", "input.source.bz2")
-        bzip2("-f", "-k", "--decompress", "liberty.jpg.bz2")
+        _bzip2("-f", "-k", "--decompress", "text.html.bz2")
+        _bzip2("-f", "-k", "--decompress", "chicken.jpg.bz2")
+        _bzip2("-f", "-k", "--decompress", "control.bz2")
+        _bzip2("-f", "-k", "--decompress", "input.source.bz2")
+        _bzip2("-f", "-k", "--decompress", "liberty.jpg.bz2")

--- a/benchbuild/projects/benchbuild/ccrypt.py
+++ b/benchbuild/projects/benchbuild/ccrypt.py
@@ -28,14 +28,18 @@ class Ccrypt(project.Project):
 
         with local.cwd(unpack_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                run.run(configure)
-            run.run(make["check"])
+                configure()
+            make_ = run.watch(make)
+            make_("check")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = 'ccrypt-{0}'.format(self.version)
         with local.cwd(unpack_dir):
             wrapping.wrap(local.path("src") / self.name, self)
             wrapping.wrap(local.path("check") / "crypt3-check", self)
             wrapping.wrap(local.path("check") / "rijndael-check", self)
-            run.run(make["check"])
+
+            make_ = run.watch(make)
+            make_("check")

--- a/benchbuild/projects/benchbuild/ccrypt.py
+++ b/benchbuild/projects/benchbuild/ccrypt.py
@@ -28,11 +28,11 @@ class Ccrypt(project.Project):
 
         with local.cwd(unpack_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                configure()
-            make_ = run.watch(make)
-            make_("check")
+                _configure()
+            _make = run.watch(make)
+            _make("check")
 
     def run_tests(self):
         unpack_dir = 'ccrypt-{0}'.format(self.version)
@@ -41,5 +41,5 @@ class Ccrypt(project.Project):
             wrapping.wrap(local.path("check") / "crypt3-check", self)
             wrapping.wrap(local.path("check") / "rijndael-check", self)
 
-            make_ = run.watch(make)
-            make_("check")
+            _make = run.watch(make)
+            _make("check")

--- a/benchbuild/projects/benchbuild/crafty.py
+++ b/benchbuild/projects/benchbuild/crafty.py
@@ -32,8 +32,8 @@ class Crafty(project.Project):
         clang = compiler.cc(self)
         with local.cwd(unpack_dir):
             target_opts = ["-DCPUS=1", "-DSYZYGY", "-DTEST"]
-            make_ = run.watch(make)
-            make_("target=UNIX", "CC=" + str(clang),
+            _make = run.watch(make)
+            _make("target=UNIX", "CC=" + str(clang),
                   "opt=" + " ".join(target_opts), "crafty-make")
 
     def run_tests(self):
@@ -41,8 +41,8 @@ class Crafty(project.Project):
         with local.cwd(unpack_dir):
             crafty = wrapping.wrap("./crafty", self)
             testdir = local.path(self.testdir)
-            test1 = run.watch((cat[testdir / "test1.sh"] | crafty))
-            test2 = run.watch((cat[testdir / "test2.sh"] | crafty))
+            _test1 = run.watch((cat[testdir / "test1.sh"] | crafty))
+            _test2 = run.watch((cat[testdir / "test2.sh"] | crafty))
 
-            test1(retcode=[0, 120])
-            test2(retcode=[0, 120])
+            _test1(retcode=[0, 120])
+            _test2(retcode=[0, 120])

--- a/benchbuild/projects/benchbuild/crocopat.py
+++ b/benchbuild/projects/benchbuild/crocopat.py
@@ -1,14 +1,12 @@
 from plumbum import local
 
 from benchbuild import project
-from benchbuild.utils import compiler, download, wrapping
+from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import cat, make, unzip
 
 
-@download.with_wget({
-    "2.1.4":
-    "http://crocopat.googlecode.com/files/crocopat-2.1.4.zip"
-})
+@download.with_wget(
+    {"2.1.4": "http://crocopat.googlecode.com/files/crocopat-2.1.4.zip"})
 class Crocopat(project.Project):
     """ crocopat benchmark """
 
@@ -18,14 +16,16 @@ class Crocopat(project.Project):
     VERSION = '2.1.4'
     SRC_FILE = "crocopat.zip"
 
-    def run_tests(self, runner):
+    def run_tests(self):
         crocopat = wrapping.wrap(self.run_f, self)
 
         programs = local.path(self.testdir) / "programs" // "*.rml"
         projects = local.path(self.testdir) / "projects" // "*.rsf"
         for program in programs:
             for _project in projects:
-                runner((cat[_project] | crocopat[program]), None)
+                crocopat_project = run.watch(
+                    (cat[_project] | crocopat[program]))
+                crocopat_project(retcode=None)
 
     def compile(self):
         self.download()
@@ -38,4 +38,5 @@ class Crocopat(project.Project):
         clang_cxx = compiler.cxx(self)
 
         with local.cwd(crocopat_dir):
-            make("CXX=" + str(clang_cxx))
+            make_ = run.watch(make)
+            make_("CXX=" + str(clang_cxx))

--- a/benchbuild/projects/benchbuild/crocopat.py
+++ b/benchbuild/projects/benchbuild/crocopat.py
@@ -23,9 +23,9 @@ class Crocopat(project.Project):
         projects = local.path(self.testdir) / "projects" // "*.rsf"
         for program in programs:
             for _project in projects:
-                crocopat_project = run.watch(
+                _crocopat_project = run.watch(
                     (cat[_project] | crocopat[program]))
-                crocopat_project(retcode=None)
+                _crocopat_project(retcode=None)
 
     def compile(self):
         self.download()
@@ -38,5 +38,5 @@ class Crocopat(project.Project):
         clang_cxx = compiler.cxx(self)
 
         with local.cwd(crocopat_dir):
-            make_ = run.watch(make)
-            make_("CXX=" + str(clang_cxx))
+            _make = run.watch(make)
+            _make("CXX=" + str(clang_cxx))

--- a/benchbuild/projects/benchbuild/ffmpeg.py
+++ b/benchbuild/projects/benchbuild/ffmpeg.py
@@ -24,8 +24,8 @@ class LibAV(project.Project):
         unpack_dir = "ffmpeg-{0}".format(self.version)
         with local.cwd(unpack_dir):
             wrapping.wrap(self.name, self)
-            make_ = run.watch(make)
-            make_("V=1", "-i", "fate")
+            _make = run.watch(make)
+            _make("V=1", "-i", "fate")
 
     def compile(self):
         self.download()
@@ -36,11 +36,11 @@ class LibAV(project.Project):
         with local.cwd(unpack_dir):
             download.Rsync(self.fate_uri, self.fate_dir)
             configure = local["./configure"]
-            configure = run.watch(configure)
-            make_ = run.watch(make)
+            _configure = run.watch(configure)
+            _make = run.watch(make)
 
-            configure("--disable-shared", "--cc=" + str(clang),
-                      "--extra-ldflags=" + " ".join(self.ldflags),
-                      "--samples=" + self.fate_dir)
-            make_("clean")
-            make_("-j{0}".format(str(get_number_of_jobs(CFG))), "all")
+            _configure("--disable-shared", "--cc=" + str(clang),
+                       "--extra-ldflags=" + " ".join(self.ldflags),
+                       "--samples=" + self.fate_dir)
+            _make("clean")
+            _make("-j{0}".format(str(get_number_of_jobs(CFG))), "all")

--- a/benchbuild/projects/benchbuild/gzip.py
+++ b/benchbuild/projects/benchbuild/gzip.py
@@ -21,23 +21,24 @@ class Gzip(project.Project):
         "text.html", "chicken.jpg", "control", "input.source", "liberty.jpg"
     ]
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path("gzip-{0}.tar.xz".format(self.version))
         gzip = wrapping.wrap(unpack_dir / "gzip", self)
+        gzip = run.watch(gzip)
 
         # Compress
-        runner(gzip["-f", "-k", "--best", "text.html"])
-        runner(gzip["-f", "-k", "--best", "chicken.jpg"])
-        runner(gzip["-f", "-k", "--best", "control"])
-        runner(gzip["-f", "-k", "--best", "input.source"])
-        runner(gzip["-f", "-k", "--best", "liberty.jpg"])
+        gzip("-f", "-k", "--best", "text.html")
+        gzip("-f", "-k", "--best", "chicken.jpg")
+        gzip("-f", "-k", "--best", "control")
+        gzip("-f", "-k", "--best", "input.source")
+        gzip("-f", "-k", "--best", "liberty.jpg")
 
         # Decompress
-        runner(gzip["-f", "-k", "--decompress", "text.html.gz"])
-        runner(gzip["-f", "-k", "--decompress", "chicken.jpg.gz"])
-        runner(gzip["-f", "-k", "--decompress", "control.gz"])
-        runner(gzip["-f", "-k", "--decompress", "input.source.gz"])
-        runner(gzip["-f", "-k", "--decompress", "liberty.jpg.gz"])
+        gzip("-f", "-k", "--decompress", "text.html.gz")
+        gzip("-f", "-k", "--decompress", "chicken.jpg.gz")
+        gzip("-f", "-k", "--decompress", "control.gz")
+        gzip("-f", "-k", "--decompress", "input.source.gz")
+        gzip("-f", "-k", "--decompress", "liberty.jpg.gz")
 
     def compile(self):
         self.download()
@@ -50,7 +51,9 @@ class Gzip(project.Project):
         clang = compiler.cc(self)
         with local.cwd(unpack_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=str(clang)):
-                run.run(configure["--disable-dependency-tracking",
-                                  "--disable-silent-rules", "--with-gnu-ld"])
-            run.run(make["-j" + str(get_number_of_jobs(CFG)), "clean", "all"])
+                configure("--disable-dependency-tracking",
+                          "--disable-silent-rules", "--with-gnu-ld")
+            make_ = run.watch(make)
+            make_("-j" + str(get_number_of_jobs(CFG)), "clean", "all")

--- a/benchbuild/projects/benchbuild/gzip.py
+++ b/benchbuild/projects/benchbuild/gzip.py
@@ -24,21 +24,21 @@ class Gzip(project.Project):
     def run_tests(self):
         unpack_dir = local.path("gzip-{0}.tar.xz".format(self.version))
         gzip = wrapping.wrap(unpack_dir / "gzip", self)
-        gzip = run.watch(gzip)
+        _gzip = run.watch(gzip)
 
         # Compress
-        gzip("-f", "-k", "--best", "text.html")
-        gzip("-f", "-k", "--best", "chicken.jpg")
-        gzip("-f", "-k", "--best", "control")
-        gzip("-f", "-k", "--best", "input.source")
-        gzip("-f", "-k", "--best", "liberty.jpg")
+        _gzip("-f", "-k", "--best", "text.html")
+        _gzip("-f", "-k", "--best", "chicken.jpg")
+        _gzip("-f", "-k", "--best", "control")
+        _gzip("-f", "-k", "--best", "input.source")
+        _gzip("-f", "-k", "--best", "liberty.jpg")
 
         # Decompress
-        gzip("-f", "-k", "--decompress", "text.html.gz")
-        gzip("-f", "-k", "--decompress", "chicken.jpg.gz")
-        gzip("-f", "-k", "--decompress", "control.gz")
-        gzip("-f", "-k", "--decompress", "input.source.gz")
-        gzip("-f", "-k", "--decompress", "liberty.jpg.gz")
+        _gzip("-f", "-k", "--decompress", "text.html.gz")
+        _gzip("-f", "-k", "--decompress", "chicken.jpg.gz")
+        _gzip("-f", "-k", "--decompress", "control.gz")
+        _gzip("-f", "-k", "--decompress", "input.source.gz")
+        _gzip("-f", "-k", "--decompress", "liberty.jpg.gz")
 
     def compile(self):
         self.download()
@@ -50,10 +50,9 @@ class Gzip(project.Project):
 
         clang = compiler.cc(self)
         with local.cwd(unpack_dir):
-            configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(local["./configure"])
             with local.env(CC=str(clang)):
-                configure("--disable-dependency-tracking",
-                          "--disable-silent-rules", "--with-gnu-ld")
-            make_ = run.watch(make)
-            make_("-j" + str(get_number_of_jobs(CFG)), "clean", "all")
+                _configure("--disable-dependency-tracking",
+                           "--disable-silent-rules", "--with-gnu-ld")
+            _make = run.watch(make)
+            _make("-j" + str(get_number_of_jobs(CFG)), "clean", "all")

--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -52,13 +52,13 @@ class SpiderMonkey(project.Project):
             with local.cwd("obj"):
                 with local.env(CC=str(clang), CXX=str(clang_cxx)):
                     configure = local["../configure"]
-                    configure = run.watch(configure)
-                    configure('--without-system-zlib')
+                    _configure = run.watch(configure)
+                    _configure('--without-system-zlib')
 
         mozjs_obj_dir = mozjs_src_dir / "obj"
         with local.cwd(mozjs_obj_dir):
-            make_ = run.watch(make)
-            make_("-j", get_number_of_jobs(CFG))
+            _make = run.watch(make)
+            _make("-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         mozjs_obj_dir = local.path("mozjs-0.0.0") / "js" / "src" / "obj"

--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -52,17 +52,19 @@ class SpiderMonkey(project.Project):
             with local.cwd("obj"):
                 with local.env(CC=str(clang), CXX=str(clang_cxx)):
                     configure = local["../configure"]
-                    configure = configure["--without-system-zlib"]
-                    run.run(configure)
+                    configure = run.watch(configure)
+                    configure('--without-system-zlib')
 
         mozjs_obj_dir = mozjs_src_dir / "obj"
         with local.cwd(mozjs_obj_dir):
-            run.run(make["-j", get_number_of_jobs(CFG)])
+            make_ = run.watch(make)
+            make_("-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         mozjs_obj_dir = local.path("mozjs-0.0.0") / "js" / "src" / "obj"
         self.runtime_extension = partial(self, may_wrap=False)
         wrapping.wrap(mozjs_obj_dir / "js" / "src" / "shell" / "js", self)
 
         with local.cwd(mozjs_obj_dir):
-            runner(make["check-jstests"])
+            make_ = run.watch(make)
+            make_("check-jstests")

--- a/benchbuild/projects/benchbuild/lammps.py
+++ b/benchbuild/projects/benchbuild/lammps.py
@@ -26,8 +26,8 @@ class Lammps(project.Project):
         for test in tests:
             dirname = test.dirname
             with local.cwd(dirname):
-                lmp_serial = run.watch((lmp_serial < test))
-                lmp_serial(retcode=None)
+                _lmp_serial = run.watch((lmp_serial < test))
+                _lmp_serial(retcode=None)
 
     def compile(self):
         self.download()
@@ -35,6 +35,6 @@ class Lammps(project.Project):
 
         clang_cxx = compiler.cxx(self)
         with local.cwd(local.path(self.src_file) / "src"):
-            make_ = run.watch(make)
-            make_("CC=" + str(clang_cxx), "LINK=" + str(clang_cxx), "clean",
+            _make = run.watch(make)
+            _make("CC=" + str(clang_cxx), "LINK=" + str(clang_cxx), "clean",
                   "serial")

--- a/benchbuild/projects/benchbuild/lammps.py
+++ b/benchbuild/projects/benchbuild/lammps.py
@@ -15,10 +15,10 @@ class Lammps(project.Project):
     SRC_FILE = 'lammps.git'
     VERSION = 'HEAD'
 
-    def run_tests(self, runner):
+    def run_tests(self):
         src_path = local.path(self.src_file)
         lammps_dir = src_path / "src"
-        exp = wrapping.wrap(lammps_dir / "lmp_serial", self)
+        lmp_serial = wrapping.wrap(lammps_dir / "lmp_serial", self)
 
         examples_dir = src_path / "examples"
         tests = examples_dir // "*" // "in.*"
@@ -26,8 +26,8 @@ class Lammps(project.Project):
         for test in tests:
             dirname = test.dirname
             with local.cwd(dirname):
-                cmd = (exp < test)
-                runner(cmd, None)
+                lmp_serial = run.watch((lmp_serial < test))
+                lmp_serial(retcode=None)
 
     def compile(self):
         self.download()
@@ -35,5 +35,6 @@ class Lammps(project.Project):
 
         clang_cxx = compiler.cxx(self)
         with local.cwd(local.path(self.src_file) / "src"):
-            run.run(make["CC=" + str(clang_cxx), "LINK=" +
-                         str(clang_cxx), "clean", "serial"])
+            make_ = run.watch(make)
+            make_("CC=" + str(clang_cxx), "LINK=" + str(clang_cxx), "clean",
+                  "serial")

--- a/benchbuild/projects/benchbuild/lapack.py
+++ b/benchbuild/projects/benchbuild/lapack.py
@@ -22,10 +22,10 @@ class OpenBlas(project.Project):
 
         clang = compiler.cc(self)
         with local.cwd(self.src_file):
-            run.run(make["CC=" + str(clang)])
+            make_ = run.watch(make)
+            make_("CC=" + str(clang))
 
-    def run_tests(self, runner):
-        del runner
+    def run_tests(self):
         log = logging.getLogger(__name__)
         log.warning('Not implemented')
 
@@ -67,29 +67,43 @@ class Lapack(project.Project):
                 ]
                 makefile.writelines(content)
 
-            run.run(make["-j", get_number_of_jobs(CFG), "f2clib", "blaslib"])
+            make_ = run.watch(make)
+            make_("-j", get_number_of_jobs(CFG), "f2clib", "blaslib")
             with local.cwd(local.path("BLAS") / "TESTING"):
-                run.run(make["-j", get_number_of_jobs(CFG), "-f", "Makeblat2"])
-                run.run(make["-j", get_number_of_jobs(CFG), "-f", "Makeblat3"])
+                make_("-j", get_number_of_jobs(CFG), "-f", "Makeblat2")
+                make_("-j", get_number_of_jobs(CFG), "-f", "Makeblat3")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path("CLAPACK-{0}".format(self.version))
         with local.cwd(unpack_dir / "BLAS"):
             xblat2s = wrapping.wrap("xblat2s", self)
+            xblat2s = run.watch((xblat2s < "sblat2.in"))
+            xblat2s()
+
             xblat2d = wrapping.wrap("xblat2d", self)
+            xblat2d = run.watch((xblat2d < "dblat2.in"))
+            xblat2d()
+
             xblat2c = wrapping.wrap("xblat2c", self)
+            xblat2c = run.watch((xblat2c < "cblat2.in"))
+            xblat2c()
+
             xblat2z = wrapping.wrap("xblat2z", self)
+            xblat2z = run.watch((xblat2z < "zblat2.in"))
+            xblat2z()
 
             xblat3s = wrapping.wrap("xblat3s", self)
-            xblat3d = wrapping.wrap("xblat3d", self)
-            xblat3c = wrapping.wrap("xblat3c", self)
-            xblat3z = wrapping.wrap("xblat3z", self)
+            xblat3s = run.watch((xblat3s < "sblat3.in"))
+            xblat3s()
 
-            runner((xblat2s < "sblat2.in"))
-            runner((xblat2d < "dblat2.in"))
-            runner((xblat2c < "cblat2.in"))
-            runner((xblat2z < "zblat2.in"))
-            runner((xblat3s < "sblat3.in"))
-            runner((xblat3d < "dblat3.in"))
-            runner((xblat3c < "cblat3.in"))
-            runner((xblat3z < "zblat3.in"))
+            xblat3d = wrapping.wrap("xblat3d", self)
+            xblat3d = run.watch((xblat3d < "dblat3.in"))
+            xblat3d()
+
+            xblat3c = wrapping.wrap("xblat3c", self)
+            xblat3c = run.watch((xblat3c < "cblat3.in"))
+            xblat3c()
+
+            xblat3z = wrapping.wrap("xblat3z", self)
+            xblat3z = run.watch((xblat3z < "zblat3.in"))
+            xblat3z()

--- a/benchbuild/projects/benchbuild/lapack.py
+++ b/benchbuild/projects/benchbuild/lapack.py
@@ -22,8 +22,8 @@ class OpenBlas(project.Project):
 
         clang = compiler.cc(self)
         with local.cwd(self.src_file):
-            make_ = run.watch(make)
-            make_("CC=" + str(clang))
+            _make = run.watch(make)
+            _make("CC=" + str(clang))
 
     def run_tests(self):
         log = logging.getLogger(__name__)
@@ -67,43 +67,43 @@ class Lapack(project.Project):
                 ]
                 makefile.writelines(content)
 
-            make_ = run.watch(make)
-            make_("-j", get_number_of_jobs(CFG), "f2clib", "blaslib")
+            _make = run.watch(make)
+            _make("-j", get_number_of_jobs(CFG), "f2clib", "blaslib")
             with local.cwd(local.path("BLAS") / "TESTING"):
-                make_("-j", get_number_of_jobs(CFG), "-f", "Makeblat2")
-                make_("-j", get_number_of_jobs(CFG), "-f", "Makeblat3")
+                _make("-j", get_number_of_jobs(CFG), "-f", "Makeblat2")
+                _make("-j", get_number_of_jobs(CFG), "-f", "Makeblat3")
 
     def run_tests(self):
         unpack_dir = local.path("CLAPACK-{0}".format(self.version))
         with local.cwd(unpack_dir / "BLAS"):
             xblat2s = wrapping.wrap("xblat2s", self)
-            xblat2s = run.watch((xblat2s < "sblat2.in"))
-            xblat2s()
+            _xblat2s = run.watch((xblat2s < "sblat2.in"))
+            _xblat2s()
 
             xblat2d = wrapping.wrap("xblat2d", self)
-            xblat2d = run.watch((xblat2d < "dblat2.in"))
-            xblat2d()
+            _xblat2d = run.watch((xblat2d < "dblat2.in"))
+            _xblat2d()
 
             xblat2c = wrapping.wrap("xblat2c", self)
-            xblat2c = run.watch((xblat2c < "cblat2.in"))
-            xblat2c()
+            _xblat2c = run.watch((xblat2c < "cblat2.in"))
+            _xblat2c()
 
             xblat2z = wrapping.wrap("xblat2z", self)
-            xblat2z = run.watch((xblat2z < "zblat2.in"))
-            xblat2z()
+            _xblat2z = run.watch((xblat2z < "zblat2.in"))
+            _xblat2z()
 
             xblat3s = wrapping.wrap("xblat3s", self)
-            xblat3s = run.watch((xblat3s < "sblat3.in"))
-            xblat3s()
+            _xblat3s = run.watch((xblat3s < "sblat3.in"))
+            _xblat3s()
 
             xblat3d = wrapping.wrap("xblat3d", self)
-            xblat3d = run.watch((xblat3d < "dblat3.in"))
-            xblat3d()
+            _xblat3d = run.watch((xblat3d < "dblat3.in"))
+            _xblat3d()
 
             xblat3c = wrapping.wrap("xblat3c", self)
-            xblat3c = run.watch((xblat3c < "cblat3.in"))
-            xblat3c()
+            _xblat3c = run.watch((xblat3c < "cblat3.in"))
+            _xblat3c()
 
             xblat3z = wrapping.wrap("xblat3z", self)
-            xblat3z = run.watch((xblat3z < "zblat3.in"))
-            xblat3z()
+            _xblat3z = run.watch((xblat3z < "zblat3.in"))
+            _xblat3z()

--- a/benchbuild/projects/benchbuild/leveldb.py
+++ b/benchbuild/projects/benchbuild/leveldb.py
@@ -22,9 +22,9 @@ class LevelDB(project.Project):
         clang_cxx = compiler.cxx(self)
         with local.cwd(self.src_file):
             with local.env(CXX=str(clang_cxx), CC=str(clang)):
-                make_ = run.watch(make)
-                make_("clean")
-                make_("all", "-i")
+                _make = run.watch(make)
+                _make("clean")
+                _make("all", "-i")
 
     def run_tests(self):
         """
@@ -35,8 +35,8 @@ class LevelDB(project.Project):
         """
         leveldb = wrapping.wrap(
             local.path(self.src_file) / "out-static" / "db_bench", self)
-        leveldb = run.watch(leveldb)
+        _leveldb = run.watch(leveldb)
         with local.env(LD_LIBRARY_PATH="{}:{}".format(
                 local.path(self.src_file) /
                 "out-shared", getenv("LD_LIBRARY_PATH", ""))):
-            leveldb()
+            _leveldb()

--- a/benchbuild/projects/benchbuild/leveldb.py
+++ b/benchbuild/projects/benchbuild/leveldb.py
@@ -22,10 +22,11 @@ class LevelDB(project.Project):
         clang_cxx = compiler.cxx(self)
         with local.cwd(self.src_file):
             with local.env(CXX=str(clang_cxx), CC=str(clang)):
-                make("clean")
-                run.run(make["all", "-i"])
+                make_ = run.watch(make)
+                make_("clean")
+                make_("all", "-i")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         """
         Execute LevelDB's runtime configuration.
 
@@ -34,7 +35,8 @@ class LevelDB(project.Project):
         """
         leveldb = wrapping.wrap(
             local.path(self.src_file) / "out-static" / "db_bench", self)
+        leveldb = run.watch(leveldb)
         with local.env(LD_LIBRARY_PATH="{}:{}".format(
                 local.path(self.src_file) /
                 "out-shared", getenv("LD_LIBRARY_PATH", ""))):
-            runner(leveldb)
+            leveldb()

--- a/benchbuild/projects/benchbuild/linpack.py
+++ b/benchbuild/projects/benchbuild/linpack.py
@@ -24,5 +24,5 @@ class Linpack(project.Project):
 
         self.ldflags += ["-lm"]
         clang = compiler.cc(self)
-        clang = run.watch(clang)
-        clang("-o", self.run_f, "linpack.c")
+        _clang = run.watch(clang)
+        _clang("-o", self.run_f, "linpack.c")

--- a/benchbuild/projects/benchbuild/linpack.py
+++ b/benchbuild/projects/benchbuild/linpack.py
@@ -24,4 +24,5 @@ class Linpack(project.Project):
 
         self.ldflags += ["-lm"]
         clang = compiler.cc(self)
-        run.run(clang["-o", self.run_f, "linpack.c"])
+        clang = run.watch(clang)
+        clang("-o", self.run_f, "linpack.c")

--- a/benchbuild/projects/benchbuild/lulesh.py
+++ b/benchbuild/projects/benchbuild/lulesh.py
@@ -1,7 +1,7 @@
 from plumbum import local
 
 from benchbuild import project
-from benchbuild.utils import compiler, download, wrapping
+from benchbuild.utils import compiler, download, run, wrapping
 
 
 @download.with_git("https://github.com/LLNL/LULESH/", limit=5)
@@ -28,10 +28,12 @@ class Lulesh(project.Project):
         with local.cwd(self.src_file):
             clang(obj_files, "-lm", "-o", "../lulesh")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         lulesh = wrapping.wrap("lulesh", self)
+        lulesh = run.watch(lulesh)
+
         for i in range(1, 15):
-            runner(lulesh["-i", i])
+            lulesh("-i", i)
 
 
 @download.with_git("https://github.com/LLNL/LULESH/", limit=5)
@@ -58,7 +60,8 @@ class LuleshOMP(project.Project):
         with local.cwd(self.src_file):
             clang(obj_files, "-lm", "-o", "../lulesh")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         lulesh = wrapping.wrap("lulesh", self)
+        lulesh = run.watch(lulesh)
         for i in range(1, 15):
-            runner(lulesh["-i", i])
+            lulesh("-i", i)

--- a/benchbuild/projects/benchbuild/lulesh.py
+++ b/benchbuild/projects/benchbuild/lulesh.py
@@ -30,10 +30,10 @@ class Lulesh(project.Project):
 
     def run_tests(self):
         lulesh = wrapping.wrap("lulesh", self)
-        lulesh = run.watch(lulesh)
+        _lulesh = run.watch(lulesh)
 
         for i in range(1, 15):
-            lulesh("-i", i)
+            _lulesh("-i", i)
 
 
 @download.with_git("https://github.com/LLNL/LULESH/", limit=5)
@@ -62,6 +62,6 @@ class LuleshOMP(project.Project):
 
     def run_tests(self):
         lulesh = wrapping.wrap("lulesh", self)
-        lulesh = run.watch(lulesh)
+        _lulesh = run.watch(lulesh)
         for i in range(1, 15):
-            lulesh("-i", i)
+            _lulesh("-i", i)

--- a/benchbuild/projects/benchbuild/mcrypt.py
+++ b/benchbuild/projects/benchbuild/mcrypt.py
@@ -49,28 +49,28 @@ class MCrypt(project.Project):
 
         _cc = compiler.cc(self)
         _cxx = compiler.cxx(self)
-        make_ = run.watch(make)
+        _make = run.watch(make)
 
         # Build mhash dependency
         with local.cwd(mhash_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
 
             with local.env(CC=_cc, CXX=_cxx):
-                configure("--prefix=" + builddir)
-                make_("-j", get_number_of_jobs(CFG), "install")
+                _configure("--prefix=" + builddir)
+                _make("-j", get_number_of_jobs(CFG), "install")
 
         # Builder libmcrypt dependency
         with local.cwd(libmcrypt_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
             with local.env(CC=_cc, CXX=_cxx):
-                configure("--prefix=" + builddir)
-                make_("-j", CFG["jobs"], "install")
+                _configure("--prefix=" + builddir)
+                _make("-j", CFG["jobs"], "install")
 
         with local.cwd(mcrypt_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
             lib_dir = builddir / "lib"
             inc_dir = builddir / "include"
             env = CFG["env"].value
@@ -83,21 +83,20 @@ class MCrypt(project.Project):
                 CFLAGS="-I" + str(inc_dir))
             env.update(mod_env)
             with local.env(**env):
-                configure("--disable-dependency-tracking",
-                                  "--enable-static", "--disable-shared",
-                                  "--with-libmcrypt=" +
-                                  builddir, "--with-libmhash=" + builddir)
-            make_("-j", get_number_of_jobs(CFG))
+                _configure("--disable-dependency-tracking",
+                           "--enable-static", "--disable-shared",
+                           "--with-libmcrypt=" +
+                           builddir, "--with-libmhash=" + builddir)
+            _make("-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         mcrypt_dir = local.path(self.builddir) / "mcrypt-2.6.8"
         mcrypt_libs = mcrypt_dir / "src" / ".libs"
 
         aestest = wrapping.wrap(mcrypt_libs / "lt-aestest", self)
-        aestest = run.watch(aestest)
-        aestest()
+        _aestest = run.watch(aestest)
+        _aestest()
 
         ciphertest = wrapping.wrap(mcrypt_libs / "lt-ciphertest", self)
-        ciphertest = run.watch(ciphertest)
-        ciphertest()
-
+        _ciphertest = run.watch(ciphertest)
+        _ciphertest()

--- a/benchbuild/projects/benchbuild/mcrypt.py
+++ b/benchbuild/projects/benchbuild/mcrypt.py
@@ -49,23 +49,28 @@ class MCrypt(project.Project):
 
         _cc = compiler.cc(self)
         _cxx = compiler.cxx(self)
+        make_ = run.watch(make)
 
         # Build mhash dependency
         with local.cwd(mhash_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
+
             with local.env(CC=_cc, CXX=_cxx):
-                run.run(configure["--prefix=" + builddir])
-                run.run(make["-j", get_number_of_jobs(CFG), "install"])
+                configure("--prefix=" + builddir)
+                make_("-j", get_number_of_jobs(CFG), "install")
 
         # Builder libmcrypt dependency
         with local.cwd(libmcrypt_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=_cc, CXX=_cxx):
-                run.run(configure["--prefix=" + builddir])
-                run.run(make["-j", get_number_of_jobs(CFG), "install"])
+                configure("--prefix=" + builddir)
+                make_("-j", CFG["jobs"], "install")
 
         with local.cwd(mcrypt_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             lib_dir = builddir / "lib"
             inc_dir = builddir / "include"
             env = CFG["env"].value
@@ -78,16 +83,21 @@ class MCrypt(project.Project):
                 CFLAGS="-I" + str(inc_dir))
             env.update(mod_env)
             with local.env(**env):
-                run.run(configure["--disable-dependency-tracking",
+                configure("--disable-dependency-tracking",
                                   "--enable-static", "--disable-shared",
-                                  "--with-libmcrypt=" + builddir,
-                                  "--with-libmhash=" + builddir])
-            run.run(make["-j", get_number_of_jobs(CFG)])
+                                  "--with-libmcrypt=" +
+                                  builddir, "--with-libmhash=" + builddir)
+            make_("-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         mcrypt_dir = local.path(self.builddir) / "mcrypt-2.6.8"
         mcrypt_libs = mcrypt_dir / "src" / ".libs"
+
         aestest = wrapping.wrap(mcrypt_libs / "lt-aestest", self)
+        aestest = run.watch(aestest)
+        aestest()
+
         ciphertest = wrapping.wrap(mcrypt_libs / "lt-ciphertest", self)
-        run.run(aestest)
-        run.run(ciphertest)
+        ciphertest = run.watch(ciphertest)
+        ciphertest()
+

--- a/benchbuild/projects/benchbuild/minisat.py
+++ b/benchbuild/projects/benchbuild/minisat.py
@@ -15,7 +15,7 @@ class Minisat(project.Project):
     SRC_FILE = 'minisat.git'
     VERSION = 'HEAD'
 
-    def run_tests(self, runner):
+    def run_tests(self):
         src_path = local.path(self.src_file)
         minisat_lib_path = src_path / "build" / "dynamic" / "lib"
         testfiles = local.path(self.testdir) // "*.cnf.gz"
@@ -23,8 +23,9 @@ class Minisat(project.Project):
         minisat = wrapping.wrap(
             src_path / "build" / "dynamic" / "bin" / "minisat", self)
         for test_f in testfiles:
-            cmd = (minisat.with_env(LD_LIBRARY_PATH=minisat_lib_path) < test_f)
-            runner(cmd, None)
+            minisat_test = run.watch(
+                (minisat.with_env(LD_LIBRARY_PATH=minisat_lib_path) < test_f))
+            minisat_test()
 
     def compile(self):
         self.download()
@@ -32,9 +33,11 @@ class Minisat(project.Project):
             git("fetch", "origin", "pull/17/head:clang")
             git("checkout", "clang")
 
-            run.run(make["config"])
+            make_ = run.watch(make)
+            make_("config")
 
             clang = compiler.cc(self)
             clang_cxx = compiler.cxx(self)
-            run.run(make["CC=" + str(clang), "CXX=" +
-                         str(clang_cxx), "clean", "lsh", "sh"])
+
+            make_("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "lsh",
+                  "sh")

--- a/benchbuild/projects/benchbuild/minisat.py
+++ b/benchbuild/projects/benchbuild/minisat.py
@@ -23,9 +23,9 @@ class Minisat(project.Project):
         minisat = wrapping.wrap(
             src_path / "build" / "dynamic" / "bin" / "minisat", self)
         for test_f in testfiles:
-            minisat_test = run.watch(
+            _minisat = run.watch(
                 (minisat.with_env(LD_LIBRARY_PATH=minisat_lib_path) < test_f))
-            minisat_test()
+            _minisat()
 
     def compile(self):
         self.download()
@@ -33,11 +33,11 @@ class Minisat(project.Project):
             git("fetch", "origin", "pull/17/head:clang")
             git("checkout", "clang")
 
-            make_ = run.watch(make)
-            make_("config")
+            _make = run.watch(make)
+            _make("config")
 
             clang = compiler.cc(self)
             clang_cxx = compiler.cxx(self)
 
-            make_("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "lsh",
+            _make("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "lsh",
                   "sh")

--- a/benchbuild/projects/benchbuild/openssl.py
+++ b/benchbuild/projects/benchbuild/openssl.py
@@ -38,19 +38,19 @@ class LibreSSL(project.Project):
         tar("xfz", self.src_file)
         unpack_dir = local.path("libressl-{0}".format(self.version))
         configure = local[unpack_dir / "configure"]
-        configure = run.watch(configure)
-        make_ = run.watch(make)
+        _configure = run.watch(configure)
+        _make = run.watch(make)
 
         with local.cwd(unpack_dir):
             with local.env(CC=str(clang)):
-                configure( 
+                _configure(
                     "--disable-asm", "--disable-shared", "--enable-static",
                     "--disable-dependency-tracking", "--with-pic=yes")
 
-            make_("-j8")
+            _make("-j8")
             make_tests = make["-Ctests", "-j8"]
-            make_tests = run.watch(make_tests)
-            make_tests(LibreSSL.BINARIES)
+            _make_tests = run.watch(make_tests)
+            _make_tests(LibreSSL.BINARIES)
 
     def run_tests(self):
         unpack_dir = local.path("libressl-{0}".format(self.version))
@@ -59,5 +59,5 @@ class LibreSSL(project.Project):
                 wrapping.wrap(local.cwd / binary, self)
 
         with local.cwd(unpack_dir):
-            make_ = run.watch(make)
-            make_("V=1", "check", "-i")
+            _make = run.watch(make)
+            _make("V=1", "check", "-i")

--- a/benchbuild/projects/benchbuild/python.py
+++ b/benchbuild/projects/benchbuild/python.py
@@ -32,13 +32,13 @@ class Python(project.Project):
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 configure("--disable-shared", "--without-gcc")
 
-            make_ = run.watch(make)
-            make_()
+            _make = run.watch(make)
+            _make()
 
     def run_tests(self):
         unpack_dir = local.path('Python-{0}'.format(self.version))
         wrapping.wrap(unpack_dir / "python", self)
 
         with local.cwd(unpack_dir):
-            make_ = run.watch(make)
-            make_("-i", "test")
+            _make = run.watch(make)
+            _make("-i", "test")

--- a/benchbuild/projects/benchbuild/python.py
+++ b/benchbuild/projects/benchbuild/python.py
@@ -28,14 +28,17 @@ class Python(project.Project):
 
         with local.cwd(unpack_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                run.run(configure["--disable-shared", "--without-gcc"])
+                configure("--disable-shared", "--without-gcc")
 
-            run.run(make)
+            make_ = run.watch(make)
+            make_()
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('Python-{0}'.format(self.version))
         wrapping.wrap(unpack_dir / "python", self)
 
         with local.cwd(unpack_dir):
-            runner(make["-i", "test"])
+            make_ = run.watch(make)
+            make_("-i", "test")

--- a/benchbuild/projects/benchbuild/rasdaman.py
+++ b/benchbuild/projects/benchbuild/rasdaman.py
@@ -31,25 +31,29 @@ class Rasdaman(project.Project):
 
         with local.cwd(gdal_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
 
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                run.run(configure["--with-pic", "--enable-static",
+                configure("--with-pic", "--enable-static",
                                   "--disable-debug", "--with-gnu-ld",
-                                  "--without-ld-shared", "--without-libtool"])
-                run.run(make["-j", get_number_of_jobs(CFG)])
+                                  "--without-ld-shared", "--without-libtool")
+                make_ = run.watch(make)
+                make_("-j", get_number_of_jobs(CFG))
 
         with local.cwd(rasdaman_dir):
             autoreconf("-i")
             configure = local["./configure"]
+            configure = run.watch(configure)
 
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                run.run(configure["--without-debug-symbols",
+                configure("--without-debug-symbols",
                                   "--enable-benchmark", "--with-static-libs",
                                   "--disable-java", "--with-pic",
-                                  "--disable-debug", "--without-docs"])
-            run.run(make["clean", "all", "-j", get_number_of_jobs(CFG)])
+                                  "--disable-debug", "--without-docs")
+            make_ = run.watch(make)
+            make_("clean", "all", "-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         import logging
         log = logging.getLogger(__name__)
         log.warning('Not implemented')

--- a/benchbuild/projects/benchbuild/rasdaman.py
+++ b/benchbuild/projects/benchbuild/rasdaman.py
@@ -31,27 +31,27 @@ class Rasdaman(project.Project):
 
         with local.cwd(gdal_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
 
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                configure("--with-pic", "--enable-static",
-                                  "--disable-debug", "--with-gnu-ld",
-                                  "--without-ld-shared", "--without-libtool")
-                make_ = run.watch(make)
-                make_("-j", get_number_of_jobs(CFG))
+                _configure("--with-pic", "--enable-static",
+                           "--disable-debug", "--with-gnu-ld",
+                           "--without-ld-shared", "--without-libtool")
+                _make = run.watch(make)
+                _make("-j", get_number_of_jobs(CFG))
 
         with local.cwd(rasdaman_dir):
             autoreconf("-i")
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
 
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                configure("--without-debug-symbols",
-                                  "--enable-benchmark", "--with-static-libs",
-                                  "--disable-java", "--with-pic",
-                                  "--disable-debug", "--without-docs")
-            make_ = run.watch(make)
-            make_("clean", "all", "-j", get_number_of_jobs(CFG))
+                _configure("--without-debug-symbols",
+                           "--enable-benchmark", "--with-static-libs",
+                           "--disable-java", "--with-pic",
+                           "--disable-debug", "--without-docs")
+            _make = run.watch(make)
+            _make("clean", "all", "-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         import logging

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -7,10 +7,8 @@ from benchbuild.utils.cmd import make, ruby, tar
 from benchbuild.utils.settings import get_number_of_jobs
 
 
-@download.with_wget({
-    '2.2.2':
-    'http://cache.ruby-lang.org/pub/ruby/2.2.2/ruby-2.2.2.tar.gz'
-})
+@download.with_wget(
+    {'2.2.2': 'http://cache.ruby-lang.org/pub/ruby/2.2.2/ruby-2.2.2.tar.gz'})
 class Ruby(project.Project):
     NAME = 'ruby'
     DOMAIN = 'compilation'
@@ -28,17 +26,20 @@ class Ruby(project.Project):
         with local.cwd(unpack_dir):
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 configure = local["./configure"]
-                run.run(configure["--with-static-linked-ext",
-                                  "--disable-shared"])
-            run.run(make["-j", get_number_of_jobs(CFG)])
+                configure = run.watch(configure)
+                configure("--with-static-linked-ext", "--disable-shared")
+            make_ = run.watch(make)
+            make_("-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('ruby-{0}'.format(self.version))
         ruby_n = wrapping.wrap(unpack_dir / "ruby", self)
         testdir = local.path(self.testdir)
 
         with local.env(RUBYOPT=""):
-            run.run(ruby[testdir / "benchmark" / "run.rb", "--ruby=\"" +
-                         str(ruby_n) + "\"", "--opts=\"-I" + testdir / "lib" +
-                         " -I" + testdir / "." + " -I" +
-                         testdir / ".ext" / "common" + "\"", "-r"])
+            ruby_ = run.watch(ruby)
+            ruby(
+                testdir / "benchmark" / "run.rb",
+                "--ruby=\"" + str(ruby_n) + "\"",
+                "--opts=\"-I" + testdir / "lib" + " -I" + testdir / "." +
+                " -I" + testdir / ".ext" / "common" + "\"", "-r")

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -28,8 +28,8 @@ class Ruby(project.Project):
                 configure = local["./configure"]
                 configure = run.watch(configure)
                 configure("--with-static-linked-ext", "--disable-shared")
-            make_ = run.watch(make)
-            make_("-j", get_number_of_jobs(CFG))
+            _make = run.watch(make)
+            _make("-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         unpack_dir = local.path('ruby-{0}'.format(self.version))
@@ -37,8 +37,8 @@ class Ruby(project.Project):
         testdir = local.path(self.testdir)
 
         with local.env(RUBYOPT=""):
-            ruby_ = run.watch(ruby)
-            ruby(
+            _ruby = run.watch(ruby)
+            _ruby(
                 testdir / "benchmark" / "run.rb",
                 "--ruby=\"" + str(ruby_n) + "\"",
                 "--opts=\"-I" + testdir / "lib" + " -I" + testdir / "." +

--- a/benchbuild/projects/benchbuild/sdcc.py
+++ b/benchbuild/projects/benchbuild/sdcc.py
@@ -23,12 +23,15 @@ class SDCC(project.Project):
 
         with local.cwd(self.SRC_FILE):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                run.run(configure["--without-ccache", "--disable-pic14-port",
-                                  "--disable-pic16-port"])
+                configure("--without-ccache", "--disable-pic14-port",
+                          "--disable-pic16-port")
 
-            run.run(make["-j", get_number_of_jobs(CFG)])
+            make_ = run.watch(make)
+            make_("-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         sdcc = wrapping.wrap(self.run_f, self)
-        runner(sdcc)
+        sdcc = run.watch(sdcc)
+        sdcc()

--- a/benchbuild/projects/benchbuild/sdcc.py
+++ b/benchbuild/projects/benchbuild/sdcc.py
@@ -23,15 +23,15 @@ class SDCC(project.Project):
 
         with local.cwd(self.SRC_FILE):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
             with local.env(CC=str(clang), CXX=str(clang_cxx)):
-                configure("--without-ccache", "--disable-pic14-port",
-                          "--disable-pic16-port")
+                _configure("--without-ccache", "--disable-pic14-port",
+                           "--disable-pic16-port")
 
-            make_ = run.watch(make)
-            make_("-j", get_number_of_jobs(CFG))
+            _make = run.watch(make)
+            _make("-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         sdcc = wrapping.wrap(self.run_f, self)
-        sdcc = run.watch(sdcc)
-        sdcc()
+        _sdcc = run.watch(sdcc)
+        _sdcc()

--- a/benchbuild/projects/benchbuild/sevenz.py
+++ b/benchbuild/projects/benchbuild/sevenz.py
@@ -31,8 +31,8 @@ class SevenZip(project.Project):
         clang_cxx = compiler.cxx(self)
 
         with local.cwd(unpack_dir):
-            make_ = run.watch(make)
-            make_("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "all")
+            _make = run.watch(make)
+            _make("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "all")
 
     def run_tests(self):
         unpack_dir = local.path('p7zip_{0}'.format(self.version))

--- a/benchbuild/projects/benchbuild/sevenz.py
+++ b/benchbuild/projects/benchbuild/sevenz.py
@@ -31,10 +31,11 @@ class SevenZip(project.Project):
         clang_cxx = compiler.cxx(self)
 
         with local.cwd(unpack_dir):
-            run.run(make["CC=" + str(clang), "CXX=" +
-                         str(clang_cxx), "clean", "all"])
+            make_ = run.watch(make)
+            make_("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "all")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('p7zip_{0}'.format(self.version))
         _7z = wrapping.wrap(unpack_dir / "bin" / "7za", self)
-        runner(_7z["b", "-mmt1"])
+        _7z = run.watch(_7z)
+        _7z("b", "-mmt1")

--- a/benchbuild/projects/benchbuild/sqlite3.py
+++ b/benchbuild/projects/benchbuild/sqlite3.py
@@ -26,11 +26,11 @@ class SQLite3(project.Project):
         SQLite3.fetch_leveldb()
 
         clang = compiler.cc(self)
-        clang = run.watch(clang)
+        _clang = run.watch(clang)
 
         with local.cwd(unpack_dir):
-            clang("-fPIC", "-I.", "-c", "sqlite3.c")
-            clang("-shared", "-o", "libsqlite3.so", "sqlite3.o", "-ldl")
+            _clang("-fPIC", "-I.", "-c", "sqlite3.c")
+            _clang("-shared", "-o", "libsqlite3.so", "sqlite3.o", "-ldl")
 
         self.build_leveldb()
 
@@ -51,8 +51,8 @@ class SQLite3(project.Project):
 
         with local.cwd(leveldb_dir):
             with local.env(CXX=str(clang_cxx), CC=str(clang)):
-                make_ = run.watch(make)
-                make_("clean", "out-static/db_bench_sqlite3")
+                _make = run.watch(make)
+                _make("clean", "out-static/db_bench_sqlite3")
 
     def run_tests(self):
         leveldb_dir = local.path("leveldb.src")
@@ -60,5 +60,5 @@ class SQLite3(project.Project):
             with local.env(LD_LIBRARY_PATH=leveldb_dir):
                 sqlite = wrapping.wrap(
                     leveldb_dir / 'out-static' / 'db_bench_sqlite3', self)
-                sqlite = run.watch(sqlite)
-                sqlite()
+                _sqlite = run.watch(sqlite)
+                _sqlite()

--- a/benchbuild/projects/benchbuild/sqlite3.py
+++ b/benchbuild/projects/benchbuild/sqlite3.py
@@ -26,11 +26,11 @@ class SQLite3(project.Project):
         SQLite3.fetch_leveldb()
 
         clang = compiler.cc(self)
+        clang = run.watch(clang)
 
         with local.cwd(unpack_dir):
-            run.run(clang["-fPIC", "-I.", "-c", "sqlite3.c"])
-            run.run(
-                clang["-shared", "-o", "libsqlite3.so", "sqlite3.o", "-ldl"])
+            clang("-fPIC", "-I.", "-c", "sqlite3.c")
+            clang("-shared", "-o", "libsqlite3.so", "sqlite3.o", "-ldl")
 
         self.build_leveldb()
 
@@ -51,12 +51,14 @@ class SQLite3(project.Project):
 
         with local.cwd(leveldb_dir):
             with local.env(CXX=str(clang_cxx), CC=str(clang)):
-                run.run(make["clean", "out-static/db_bench_sqlite3"])
+                make_ = run.watch(make)
+                make_("clean", "out-static/db_bench_sqlite3")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         leveldb_dir = local.path("leveldb.src")
         with local.cwd(leveldb_dir):
             with local.env(LD_LIBRARY_PATH=leveldb_dir):
                 sqlite = wrapping.wrap(
                     leveldb_dir / 'out-static' / 'db_bench_sqlite3', self)
-                run.run(sqlite)
+                sqlite = run.watch(sqlite)
+                sqlite()

--- a/benchbuild/projects/benchbuild/tcc.py
+++ b/benchbuild/projects/benchbuild/tcc.py
@@ -30,17 +30,17 @@ class TCC(project.Project):
             mkdir("build")
             with local.cwd("build"):
                 configure = local["../configure"]
-                confiugre = run.watch(configure)
-                configure("--cc=" + str(clang), "--with-libgcc")
+                _configure = run.watch(configure)
+                _configure("--cc=" + str(clang), "--with-libgcc")
 
-                make_ = run.watch(make)
-                make_()
+                _make = run.watch(make)
+                _make()
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('tcc-{0}.tar.bz2'.format(self.version))
         with local.cwd(unpack_dir):
             with local.cwd("build"):
                 wrapping.wrap("tcc", self)
                 inc_path = path.abspath("..")
-                make_ = run.watch(make)
-                make_("TCCFLAGS=-B{}".format(inc_path), "test", "-i")
+                _make = run.watch(make)
+                _make("TCCFLAGS=-B{}".format(inc_path), "test", "-i")

--- a/benchbuild/projects/benchbuild/tcc.py
+++ b/benchbuild/projects/benchbuild/tcc.py
@@ -30,8 +30,11 @@ class TCC(project.Project):
             mkdir("build")
             with local.cwd("build"):
                 configure = local["../configure"]
-                run.run(configure["--cc=" + str(clang), "--with-libgcc"])
-                run.run(make)
+                confiugre = run.watch(configure)
+                configure("--cc=" + str(clang), "--with-libgcc")
+
+                make_ = run.watch(make)
+                make_()
 
     def run_tests(self, runner):
         unpack_dir = local.path('tcc-{0}.tar.bz2'.format(self.version))
@@ -39,4 +42,5 @@ class TCC(project.Project):
             with local.cwd("build"):
                 wrapping.wrap("tcc", self)
                 inc_path = path.abspath("..")
-                runner(make["TCCFLAGS=-B{}".format(inc_path), "test", "-i"])
+                make_ = run.watch(make)
+                make_("TCCFLAGS=-B{}".format(inc_path), "test", "-i")

--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -34,18 +34,18 @@ class X264(project.Project):
 
         with local.cwd(self.SRC_FILE):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
 
             with local.env(CC=str(clang)):
-                configure("--disable-thread", "--disable-opencl",
-                          "--enable-pic")
+                _configure("--disable-thread", "--disable-opencl",
+                           "--enable-pic")
 
-            make_ = run.watch(make)
-            make_("clean", "all", "-j", get_number_of_jobs(CFG))
+            _make = run.watch(make)
+            _make("clean", "all", "-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
         x264 = wrapping.wrap(local.path(self.src_file) / "x264", self)
-        x264 = run.watch(x264)
+        _x264 = run.watch(x264)
 
         tests = [
             "--crf 30 -b1 -m1 -r1 --me dia --no-cabac --direct temporal --ssim --no-weightb",
@@ -61,5 +61,5 @@ class X264(project.Project):
         for ifile in self.inputfiles:
             testfile = local.path(self.testdir) / ifile
             for _, test in enumerate(tests):
-                x264(testfile, self.inputfiles[ifile], "--threads", "1", "-o",
-                     "/dev/null", test.split(" "))
+                _x264(testfile, self.inputfiles[ifile], "--threads", "1", "-o",
+                      "/dev/null", test.split(" "))

--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -7,8 +7,7 @@ from benchbuild.utils.cmd import cp, make
 from benchbuild.utils.settings import get_number_of_jobs
 
 
-@download.with_git(
-    "git://git.videolan.org/x264.git", refspec="HEAD", limit=5)
+@download.with_git("git://git.videolan.org/x264.git", refspec="HEAD", limit=5)
 class X264(project.Project):
     """ x264 """
 
@@ -35,15 +34,18 @@ class X264(project.Project):
 
         with local.cwd(self.SRC_FILE):
             configure = local["./configure"]
+            configure = run.watch(configure)
 
             with local.env(CC=str(clang)):
-                run.run(configure["--disable-thread", "--disable-opencl",
-                                  "--enable-pic"])
+                configure("--disable-thread", "--disable-opencl",
+                          "--enable-pic")
 
-            run.run(make["clean", "all", "-j", get_number_of_jobs(CFG)])
+            make_ = run.watch(make)
+            make_("clean", "all", "-j", get_number_of_jobs(CFG))
 
-    def run_tests(self, runner):
+    def run_tests(self):
         x264 = wrapping.wrap(local.path(self.src_file) / "x264", self)
+        x264 = run.watch(x264)
 
         tests = [
             "--crf 30 -b1 -m1 -r1 --me dia --no-cabac --direct temporal --ssim --no-weightb",
@@ -59,6 +61,5 @@ class X264(project.Project):
         for ifile in self.inputfiles:
             testfile = local.path(self.testdir) / ifile
             for _, test in enumerate(tests):
-                runner(x264[testfile, self.inputfiles[ifile], "--threads", "1",
-                            "-o", "/dev/null",
-                            test.split(" ")])
+                x264(testfile, self.inputfiles[ifile], "--threads", "1", "-o",
+                     "/dev/null", test.split(" "))

--- a/benchbuild/projects/benchbuild/xz.py
+++ b/benchbuild/projects/benchbuild/xz.py
@@ -31,21 +31,21 @@ class XZ(project.Project):
         clang = compiler.cc(self)
         with local.cwd(unpack_dir):
             configure = local["./configure"]
-            configure = run.watch(configure)
+            _configure = run.watch(configure)
             with local.env(CC=str(clang)):
-                configure("--enable-threads=no", "--with-gnu-ld=yes",
-                          "--disable-shared", "--disable-dependency-tracking",
-                          "--disable-xzdec", "--disable-lzmadec",
-                          "--disable-lzmainfo", "--disable-lzma-links",
-                          "--disable-scripts", "--disable-doc")
+                _configure("--enable-threads=no", "--with-gnu-ld=yes",
+                           "--disable-shared", "--disable-dependency-tracking",
+                           "--disable-xzdec", "--disable-lzmadec",
+                           "--disable-lzmainfo", "--disable-lzma-links",
+                           "--disable-scripts", "--disable-doc")
 
-            make_ = run.watch(make)
-            make_("CC=" + str(clang), "clean", "all")
+            _make = run.watch(make)
+            _make("CC=" + str(clang), "clean", "all")
 
     def run_tests(self):
         unpack_dir = local.path('xz-{0}'.format(self.version))
-        _xz = wrapping.wrap(unpack_dir / "src" / "xz" / "xz", self)
-        _xz = run.watch(_xz)
+        xz = wrapping.wrap(unpack_dir / "src" / "xz" / "xz", self)
+        _xz = run.watch(xz)
 
         # Compress
         _xz("--compress", "-f", "-k", "-e", "-9", "text.html")

--- a/benchbuild/projects/benchbuild/xz.py
+++ b/benchbuild/projects/benchbuild/xz.py
@@ -31,30 +31,32 @@ class XZ(project.Project):
         clang = compiler.cc(self)
         with local.cwd(unpack_dir):
             configure = local["./configure"]
+            configure = run.watch(configure)
             with local.env(CC=str(clang)):
-                run.run(configure["--enable-threads=no", "--with-gnu-ld=yes",
-                                  "--disable-shared",
-                                  "--disable-dependency-tracking",
-                                  "--disable-xzdec", "--disable-lzmadec",
-                                  "--disable-lzmainfo", "--disable-lzma-links",
-                                  "--disable-scripts", "--disable-doc"])
+                configure("--enable-threads=no", "--with-gnu-ld=yes",
+                          "--disable-shared", "--disable-dependency-tracking",
+                          "--disable-xzdec", "--disable-lzmadec",
+                          "--disable-lzmainfo", "--disable-lzma-links",
+                          "--disable-scripts", "--disable-doc")
 
-            run.run(make["CC=" + str(clang), "clean", "all"])
+            make_ = run.watch(make)
+            make_("CC=" + str(clang), "clean", "all")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         unpack_dir = local.path('xz-{0}'.format(self.version))
         _xz = wrapping.wrap(unpack_dir / "src" / "xz" / "xz", self)
+        _xz = run.watch(_xz)
 
         # Compress
-        runner(_xz["--compress", "-f", "-k", "-e", "-9", "text.html"])
-        runner(_xz["--compress", "-f", "-k", "-e", "-9", "chicken.jpg"])
-        runner(_xz["--compress", "-f", "-k", "-e", "-9", "control"])
-        runner(_xz["--compress", "-f", "-k", "-e", "-9", "input.source"])
-        runner(_xz["--compress", "-f", "-k", "-e", "-9", "liberty.jpg"])
+        _xz("--compress", "-f", "-k", "-e", "-9", "text.html")
+        _xz("--compress", "-f", "-k", "-e", "-9", "chicken.jpg")
+        _xz("--compress", "-f", "-k", "-e", "-9", "control")
+        _xz("--compress", "-f", "-k", "-e", "-9", "input.source")
+        _xz("--compress", "-f", "-k", "-e", "-9", "liberty.jpg")
 
         # Decompress
-        runner(_xz["--decompress", "-f", "-k", "text.html.xz"])
-        runner(_xz["--decompress", "-f", "-k", "chicken.jpg.xz"])
-        runner(_xz["--decompress", "-f", "-k", "control.xz"])
-        runner(_xz["--decompress", "-f", "-k", "input.source.xz"])
-        runner(_xz["--decompress", "-f", "-k", "liberty.jpg.xz"])
+        _xz("--decompress", "-f", "-k", "text.html.xz")
+        _xz("--decompress", "-f", "-k", "chicken.jpg.xz")
+        _xz("--decompress", "-f", "-k", "control.xz")
+        _xz("--decompress", "-f", "-k", "input.source.xz")
+        _xz("--decompress", "-f", "-k", "liberty.jpg.xz")

--- a/benchbuild/projects/gentoo/autoportage.py
+++ b/benchbuild/projects/gentoo/autoportage.py
@@ -22,7 +22,6 @@ class AutoPortage(GentooGroup):
                 retcode=None)
         uchroot.uretry(emerge_in_chroot[prog])
 
-    def run_tests(self, runner):
-        del runner  # Unused
+    def run_tests(self):
         log = logging.getLogger(__name__)
         log.warning('Not implemented')

--- a/benchbuild/projects/gentoo/bzip2.py
+++ b/benchbuild/projects/gentoo/bzip2.py
@@ -4,7 +4,7 @@ bzip2 experiment within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 from benchbuild.utils.cmd import tar
 
 
@@ -29,22 +29,20 @@ class BZip2(GentooGroup):
         download.Wget(test_url, test_archive)
         tar("fxz", test_archive)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         bzip2 = wrapping.wrap(local.path('/bin/bzip2'), self)
+        bzip2 = run.watch(bzip2)
 
         # Compress
-        runner(bzip2["-f", "-z", "-k", "--best", "compression/text.html"])
-        runner(bzip2["-f", "-z", "-k", "--best", "compression/chicken.jpg"])
-        runner(bzip2["-f", "-z", "-k", "--best", "compression/control"])
-        runner(bzip2["-f", "-z", "-k", "--best", "compression/input.source"])
-        runner(bzip2["-f", "-z", "-k", "--best", "compression/liberty.jpg"])
+        bzip2("-f", "-z", "-k", "--best", "compression/text.html")
+        bzip2("-f", "-z", "-k", "--best", "compression/chicken.jpg")
+        bzip2("-f", "-z", "-k", "--best", "compression/control")
+        bzip2("-f", "-z", "-k", "--best", "compression/input.source")
+        bzip2("-f", "-z", "-k", "--best", "compression/liberty.jpg")
 
         # Decompress
-        runner(bzip2["-f", "-k", "--decompress", "compression/text.html.bz2"])
-        runner(
-            bzip2["-f", "-k", "--decompress", "compression/chicken.jpg.bz2"])
-        runner(bzip2["-f", "-k", "--decompress", "compression/control.bz2"])
-        runner(
-            bzip2["-f", "-k", "--decompress", "compression/input.source.bz2"])
-        runner(
-            bzip2["-f", "-k", "--decompress", "compression/liberty.jpg.bz2"])
+        bzip2("-f", "-k", "--decompress", "compression/text.html.bz2")
+        bzip2("-f", "-k", "--decompress", "compression/chicken.jpg.bz2")
+        bzip2("-f", "-k", "--decompress", "compression/control.bz2")
+        bzip2("-f", "-k", "--decompress", "compression/input.source.bz2")
+        bzip2("-f", "-k", "--decompress", "compression/liberty.jpg.bz2")

--- a/benchbuild/projects/gentoo/crafty.py
+++ b/benchbuild/projects/gentoo/crafty.py
@@ -4,7 +4,7 @@ crafty experiment within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 from benchbuild.utils.cmd import cat
 
 
@@ -22,7 +22,7 @@ class Crafty(GentooGroup):
         book_bin = "http://www.craftychess.com/" + book_file
         download.Wget(book_bin, book_file)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         crafty_path = local.path("/usr/bin/crafty")
         crafty = wrapping.wrap(crafty_path, self)
 
@@ -108,5 +108,8 @@ quit
 
             test2.write(lines)
 
-        runner((cat["test1.sh"] | crafty))
-        runner((cat["test2.sh"] | crafty))
+        crafty_test1 = run.watch((cat['test1.sh'] | crafty))
+        crafty_test1()
+
+        crafty_test2 = run.watch((cat['test2.sh'] | crafty))
+        crafty_test2()

--- a/benchbuild/projects/gentoo/eix.py
+++ b/benchbuild/projects/gentoo/eix.py
@@ -4,7 +4,7 @@ eix experiment within gentoo chroot
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import wrapping
+from benchbuild.utils import run, wrapping
 
 
 class Eix(GentooGroup):
@@ -13,8 +13,9 @@ class Eix(GentooGroup):
     NAME = 'eix'
     DOMAIN = 'app-portage'
 
-    def run_tests(self, runner):
+    def run_tests(self):
         """Runs runtime tests for eix"""
 
         eix = wrapping.wrap(local.path('/usr/bin/eix'), self)
-        runner(eix["clang"])
+        eix = run.watch(eix)
+        eix("clang")

--- a/benchbuild/projects/gentoo/eix.py
+++ b/benchbuild/projects/gentoo/eix.py
@@ -17,5 +17,5 @@ class Eix(GentooGroup):
         """Runs runtime tests for eix"""
 
         eix = wrapping.wrap(local.path('/usr/bin/eix'), self)
-        eix = run.watch(eix)
-        eix("clang")
+        _eix = run.watch(eix)
+        _eix("clang")

--- a/benchbuild/projects/gentoo/gentoo.py
+++ b/benchbuild/projects/gentoo/gentoo.py
@@ -46,9 +46,10 @@ class GentooGroup(project.Project):
         self.configure_benchbuild(CFG)
         path.mkfile_uchroot("/.benchbuild-container")
         benchbuild = find_benchbuild()
+        benchbuild = run.watch(benchbuild)
         with local.env(BB_VERBOSITY=str(CFG['verbosity'])):
             project_id = "{0}/{1}".format(self.name, self.group)
-            run.run(benchbuild["run", "-E", self.experiment.name, project_id])
+            benchbuild("run", "-E", self.experiment.name, project_id)
 
     def compile(self):
         package_atom = "{domain}/{name}".format(
@@ -100,7 +101,8 @@ def emerge(package, *args, env=None):
     from benchbuild.utils.cmd import emerge as _emerge
 
     with local.env(env):
-        run.run(_emerge["--autounmask-continue", args, package])
+        emerge_ = run.watch(_emerge)
+        emerge_("--autounmask-continue", args, package)
 
 
 def setup_networking():

--- a/benchbuild/projects/gentoo/gentoo.py
+++ b/benchbuild/projects/gentoo/gentoo.py
@@ -46,10 +46,10 @@ class GentooGroup(project.Project):
         self.configure_benchbuild(CFG)
         path.mkfile_uchroot("/.benchbuild-container")
         benchbuild = find_benchbuild()
-        benchbuild = run.watch(benchbuild)
+        _benchbuild = run.watch(benchbuild)
         with local.env(BB_VERBOSITY=str(CFG['verbosity'])):
             project_id = "{0}/{1}".format(self.name, self.group)
-            benchbuild("run", "-E", self.experiment.name, project_id)
+            _benchbuild("run", "-E", self.experiment.name, project_id)
 
     def compile(self):
         package_atom = "{domain}/{name}".format(
@@ -98,11 +98,11 @@ class GentooGroup(project.Project):
 
 
 def emerge(package, *args, env=None):
-    from benchbuild.utils.cmd import emerge as _emerge
+    from benchbuild.utils.cmd import emerge as gentoo_emerge
 
     with local.env(env):
-        emerge_ = run.watch(_emerge)
-        emerge_("--autounmask-continue", args, package)
+        _emerge = run.watch(gentoo_emerge)
+        _emerge("--autounmask-continue", args, package)
 
 
 def setup_networking():

--- a/benchbuild/projects/gentoo/gzip.py
+++ b/benchbuild/projects/gentoo/gzip.py
@@ -4,7 +4,7 @@ gzip experiment within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 from benchbuild.utils.cmd import tar
 
 
@@ -29,19 +29,20 @@ class GZip(GentooGroup):
         download.Wget(test_url, test_archive)
         tar("fxz", test_archive)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         gzip = wrapping.wrap(local.path('/bin/gzip'), self)
+        gzip = run.watch(gzip)
 
         # Compress
-        runner(gzip["-f", "-k", "--best", "compression/text.html"])
-        runner(gzip["-f", "-k", "--best", "compression/chicken.jpg"])
-        runner(gzip["-f", "-k", "--best", "compression/control"])
-        runner(gzip["-f", "-k", "--best", "compression/input.source"])
-        runner(gzip["-f", "-k", "--best", "compression/liberty.jpg"])
+        gzip("-f", "-k", "--best", "compression/text.html")
+        gzip("-f", "-k", "--best", "compression/chicken.jpg")
+        gzip("-f", "-k", "--best", "compression/control")
+        gzip("-f", "-k", "--best", "compression/input.source")
+        gzip("-f", "-k", "--best", "compression/liberty.jpg")
 
         # Decompress
-        runner(gzip["-f", "-k", "--decompress", "compression/text.html.gz"])
-        runner(gzip["-f", "-k", "--decompress", "compression/chicken.jpg.gz"])
-        runner(gzip["-f", "-k", "--decompress", "compression/control.gz"])
-        runner(gzip["-f", "-k", "--decompress", "compression/input.source.gz"])
-        runner(gzip["-f", "-k", "--decompress", "compression/liberty.jpg.gz"])
+        gzip("-f", "-k", "--decompress", "compression/text.html.gz")
+        gzip("-f", "-k", "--decompress", "compression/chicken.jpg.gz")
+        gzip("-f", "-k", "--decompress", "compression/control.gz")
+        gzip("-f", "-k", "--decompress", "compression/input.source.gz")
+        gzip("-f", "-k", "--decompress", "compression/liberty.jpg.gz")

--- a/benchbuild/projects/gentoo/info.py
+++ b/benchbuild/projects/gentoo/info.py
@@ -22,9 +22,9 @@ class Info(ap.AutoPortage):
     def compile(self):
         with local.env(CC="gcc", CXX="g++"):
             emerge_in_chroot = uchroot.uchroot()["/usr/bin/emerge"]
-            emerge_in_chroot = run.watch(emerge_in_chroot)
-            emerge_in_chroot("app-portage/portage-utils")
-            emerge_in_chroot("app-portage/gentoolkit")
+            _emerge_in_chroot = run.watch(emerge_in_chroot)
+            _emerge_in_chroot("app-portage/portage-utils")
+            _emerge_in_chroot("app-portage/gentoolkit")
 
         qgrep_in_chroot = uchroot.uchroot()["/usr/bin/qgrep"]
         equery_in_chroot = uchroot.uchroot()["/usr/bin/equery"]

--- a/benchbuild/projects/gentoo/info.py
+++ b/benchbuild/projects/gentoo/info.py
@@ -22,8 +22,9 @@ class Info(ap.AutoPortage):
     def compile(self):
         with local.env(CC="gcc", CXX="g++"):
             emerge_in_chroot = uchroot.uchroot()["/usr/bin/emerge"]
-            run.run(emerge_in_chroot["app-portage/portage-utils"])
-            run.run(emerge_in_chroot["app-portage/gentoolkit"])
+            emerge_in_chroot = run.watch(emerge_in_chroot)
+            emerge_in_chroot("app-portage/portage-utils")
+            emerge_in_chroot("app-portage/gentoolkit")
 
         qgrep_in_chroot = uchroot.uchroot()["/usr/bin/qgrep"]
         equery_in_chroot = uchroot.uchroot()["/usr/bin/equery"]

--- a/benchbuild/projects/gentoo/lammps.py
+++ b/benchbuild/projects/gentoo/lammps.py
@@ -36,5 +36,6 @@ class Lammps(GentooGroup):
         with local.cwd(lammps_dir):
             tests = lammps_dir // "in.*"
             for test in tests:
-                lammps_test = run.watch((lammps < wrapping.strip_path_prefix(test, builddir)))
-                lammps_test()
+                _lammps_test = run.watch(
+                    (lammps < wrapping.strip_path_prefix(test, builddir)))
+                _lammps_test()

--- a/benchbuild/projects/gentoo/lammps.py
+++ b/benchbuild/projects/gentoo/lammps.py
@@ -4,7 +4,7 @@ LAMMPS (sci-physics/lammps) project within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 from benchbuild.utils.cmd import tar
 
 
@@ -28,7 +28,7 @@ class Lammps(GentooGroup):
         download.Wget(test_url, test_archive)
         tar("fxz", test_archive)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         builddir = self.builddir
         lammps = wrapping.wrap(local.path('/usr/bin/lmp'), self)
         lammps_dir = builddir / "lammps"
@@ -36,4 +36,5 @@ class Lammps(GentooGroup):
         with local.cwd(lammps_dir):
             tests = lammps_dir // "in.*"
             for test in tests:
-                runner((lammps < wrapping.strip_path_prefix(test, builddir)))
+                lammps_test = run.watch((lammps < wrapping.strip_path_prefix(test, builddir)))
+                lammps_test()

--- a/benchbuild/projects/gentoo/portage_gen.py
+++ b/benchbuild/projects/gentoo/portage_gen.py
@@ -45,8 +45,8 @@ class FuncClass:
             with local.env(CONFIG_PROTECT="-*"):
                 fake_emerge = _uchroot["emerge", "--autounmask-only=y",
                                        "--autounmask-write=y", "--nodeps"]
-                fake_emerge = run.watch(fake_emerge)
-                fake_emerge(package)
+                _fake_emerge = run.watch(fake_emerge)
+                _fake_emerge(package)
 
             emerge_in_chroot = \
                 _uchroot["emerge", "-p", "--nodeps", package]

--- a/benchbuild/projects/gentoo/portage_gen.py
+++ b/benchbuild/projects/gentoo/portage_gen.py
@@ -45,7 +45,8 @@ class FuncClass:
             with local.env(CONFIG_PROTECT="-*"):
                 fake_emerge = _uchroot["emerge", "--autounmask-only=y",
                                        "--autounmask-write=y", "--nodeps"]
-                run.run(fake_emerge[package])
+                fake_emerge = run.watch(fake_emerge)
+                fake_emerge(package)
 
             emerge_in_chroot = \
                 _uchroot["emerge", "-p", "--nodeps", package]

--- a/benchbuild/projects/gentoo/postgresql.py
+++ b/benchbuild/projects/gentoo/postgresql.py
@@ -7,7 +7,7 @@ from plumbum import local
 from psutil import Process
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import wrapping
+from benchbuild.utils import run, wrapping
 from benchbuild.utils.cmd import kill, su
 
 
@@ -26,7 +26,7 @@ class Postgresql(GentooGroup):
         if not pg_socketdir.exists():
             pg_socketdir.mkdir()
 
-    def run_tests(self, runner):
+    def run_tests(self):
         pg_data = local.path("/test-data/")
         pg_path = local.path("/usr/bin/postgres")
 
@@ -36,14 +36,22 @@ class Postgresql(GentooGroup):
             return su['-c', command, '-g', 'postgres', 'postgres']
 
         dropdb = pg_su('/usr/bin/dropdb')
+        dropdb = run.watch(dropdb)
+
         createdb = pg_su("/usr/bin/createdb")
+        createdb = run.watch(createdb)
+
         pgbench = pg_su("/usr/bin/pgbench")
+        pgbench = run.watch(pgbench)
+
         initdb = pg_su("/usr/bin/initdb")
+        initdb = run.watch(initdb)
+
         pg_server = pg_su(pg_path)
 
         with local.env(PGPORT="54329", PGDATA=pg_data):
             if not pg_data.exists():
-                runner(initdb)
+                initdb()
 
             with pg_server.bgrun() as postgres:
                 #We get the PID of the running 'pg_server, which is actually
@@ -63,9 +71,9 @@ class Postgresql(GentooGroup):
                     and c.parent().name() != 'postgres.bin'
                 ]
                 try:
-                    runner(createdb)
-                    runner(pgbench["-i", "portage"])
-                    runner(pgbench["-c", 1, "-S", "-t", 1000000, "portage"])
-                    runner(dropdb["portage"])
+                    createdb()
+                    pgbench("-i", "portage")
+                    pgbench("-c", 1, "-S", "-t", 1000000, "portage")
+                    dropdb("portage")
                 finally:
                     kill("-sSIGTERM", real_postgres[0])

--- a/benchbuild/projects/gentoo/postgresql.py
+++ b/benchbuild/projects/gentoo/postgresql.py
@@ -36,22 +36,22 @@ class Postgresql(GentooGroup):
             return su['-c', command, '-g', 'postgres', 'postgres']
 
         dropdb = pg_su('/usr/bin/dropdb')
-        dropdb = run.watch(dropdb)
+        _dropdb = run.watch(dropdb)
 
         createdb = pg_su("/usr/bin/createdb")
-        createdb = run.watch(createdb)
+        _createdb = run.watch(createdb)
 
         pgbench = pg_su("/usr/bin/pgbench")
-        pgbench = run.watch(pgbench)
+        _pgbench = run.watch(pgbench)
 
         initdb = pg_su("/usr/bin/initdb")
-        initdb = run.watch(initdb)
+        _initdb = run.watch(initdb)
 
         pg_server = pg_su(pg_path)
 
         with local.env(PGPORT="54329", PGDATA=pg_data):
             if not pg_data.exists():
-                initdb()
+                _initdb()
 
             with pg_server.bgrun() as postgres:
                 #We get the PID of the running 'pg_server, which is actually
@@ -71,9 +71,9 @@ class Postgresql(GentooGroup):
                     and c.parent().name() != 'postgres.bin'
                 ]
                 try:
-                    createdb()
-                    pgbench("-i", "portage")
-                    pgbench("-c", 1, "-S", "-t", 1000000, "portage")
-                    dropdb("portage")
+                    _createdb()
+                    _pgbench("-i", "portage")
+                    _pgbench("-c", 1, "-S", "-t", 1000000, "portage")
+                    _dropdb("portage")
                 finally:
                     kill("-sSIGTERM", real_postgres[0])

--- a/benchbuild/projects/gentoo/sevenz.py
+++ b/benchbuild/projects/gentoo/sevenz.py
@@ -14,7 +14,7 @@ class SevenZip(GentooGroup):
     NAME = "p7zip"
     DOMAIN = "app-arch"
 
-    def run_tests(self, runner):
+    def run_tests(self):
         _7z = wrapping.wrap(local.path('/usr/bin/7z'), self)
         _7z = run.watch(_7z)
         _7z("b", "-mmt1")

--- a/benchbuild/projects/gentoo/sevenz.py
+++ b/benchbuild/projects/gentoo/sevenz.py
@@ -4,7 +4,7 @@ p7zip experiment within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import wrapping
+from benchbuild.utils import run, wrapping
 
 
 class SevenZip(GentooGroup):
@@ -16,4 +16,5 @@ class SevenZip(GentooGroup):
 
     def run_tests(self, runner):
         _7z = wrapping.wrap(local.path('/usr/bin/7z'), self)
-        runner(_7z["b", "-mmt1"])
+        _7z = run.watch(_7z)
+        _7z("b", "-mmt1")

--- a/benchbuild/projects/gentoo/x264.py
+++ b/benchbuild/projects/gentoo/x264.py
@@ -28,7 +28,7 @@ class X264(GentooGroup):
 
     def run_tests(self, runner):
         x264 = wrapping.wrap(local.path('/usr/bin/x264'), self)
-        x264 = run.watch(x264)
+        _x264 = run.watch(x264)
 
         tests = [
             "--crf 30 -b1 -m1 -r1 --me dia --no-cabac --direct temporal --ssim --no-weightb",
@@ -43,5 +43,5 @@ class X264(GentooGroup):
 
         for ifile in self.inputfiles:
             for _, test in enumerate(tests):
-                x264(ifile, self.inputfiles[ifile], "--threads", "1", "-o",
-                     "/dev/null", test.split(" "))
+                _x264(ifile, self.inputfiles[ifile], "--threads", "1", "-o",
+                      "/dev/null", test.split(" "))

--- a/benchbuild/projects/gentoo/x264.py
+++ b/benchbuild/projects/gentoo/x264.py
@@ -4,7 +4,7 @@ media-video/x264-encoder within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 
 
 class X264(GentooGroup):
@@ -28,6 +28,7 @@ class X264(GentooGroup):
 
     def run_tests(self, runner):
         x264 = wrapping.wrap(local.path('/usr/bin/x264'), self)
+        x264 = run.watch(x264)
 
         tests = [
             "--crf 30 -b1 -m1 -r1 --me dia --no-cabac --direct temporal --ssim --no-weightb",
@@ -42,6 +43,5 @@ class X264(GentooGroup):
 
         for ifile in self.inputfiles:
             for _, test in enumerate(tests):
-                runner(x264[ifile, self.inputfiles[ifile], "--threads", "1",
-                            "-o", "/dev/null",
-                            test.split(" ")])
+                x264(ifile, self.inputfiles[ifile], "--threads", "1", "-o",
+                     "/dev/null", test.split(" "))

--- a/benchbuild/projects/gentoo/xz.py
+++ b/benchbuild/projects/gentoo/xz.py
@@ -4,7 +4,7 @@ xz experiment within gentoo chroot.
 from plumbum import local
 
 from benchbuild.projects.gentoo.gentoo import GentooGroup
-from benchbuild.utils import download, wrapping
+from benchbuild.utils import download, run, wrapping
 from benchbuild.utils.cmd import tar
 
 
@@ -29,23 +29,20 @@ class XZ(GentooGroup):
         download.Wget(test_url, test_archive)
         tar("fxz", test_archive)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         xz = wrapping.wrap(local.path("/usr/bin/xz"), self)
+        xz = run.watch(xz)
 
         # Compress
-        runner(
-            xz["--compress", "-f", "-k", "-e", "-9", "compression/text.html"])
-        runner(xz["--compress", "-f", "-k", "-e", "-9",
-                  "compression/chicken.jpg"])
-        runner(xz["--compress", "-f", "-k", "-e", "-9", "compression/control"])
-        runner(xz["--compress", "-f", "-k", "-e", "-9",
-                  "compression/input.source"])
-        runner(xz["--compress", "-f", "-k", "-e", "-9",
-                  "compression/liberty.jpg"])
+        xz("--compress", "-f", "-k", "-e", "-9", "compression/text.html")
+        xz("--compress", "-f", "-k", "-e", "-9", "compression/chicken.jpg")
+        xz("--compress", "-f", "-k", "-e", "-9", "compression/control")
+        xz("--compress", "-f", "-k", "-e", "-9", "compression/input.source")
+        xz("--compress", "-f", "-k", "-e", "-9", "compression/liberty.jpg")
 
         # Decompress
-        runner(xz["--decompress", "-f", "-k", "compression/text.html.xz"])
-        runner(xz["--decompress", "-f", "-k", "compression/chicken.jpg.xz"])
-        runner(xz["--decompress", "-f", "-k", "compression/control.xz"])
-        runner(xz["--decompress", "-f", "-k", "compression/input.source.xz"])
-        runner(xz["--decompress", "-f", "-k", "compression/liberty.jpg.xz"])
+        xz("--decompress", "-f", "-k", "compression/text.html.xz")
+        xz("--decompress", "-f", "-k", "compression/chicken.jpg.xz")
+        xz("--decompress", "-f", "-k", "compression/control.xz")
+        xz("--decompress", "-f", "-k", "compression/input.source.xz")
+        xz("--decompress", "-f", "-k", "compression/liberty.jpg.xz")

--- a/benchbuild/projects/gentoo/xz.py
+++ b/benchbuild/projects/gentoo/xz.py
@@ -31,18 +31,18 @@ class XZ(GentooGroup):
 
     def run_tests(self):
         xz = wrapping.wrap(local.path("/usr/bin/xz"), self)
-        xz = run.watch(xz)
+        _xz = run.watch(xz)
 
         # Compress
-        xz("--compress", "-f", "-k", "-e", "-9", "compression/text.html")
-        xz("--compress", "-f", "-k", "-e", "-9", "compression/chicken.jpg")
-        xz("--compress", "-f", "-k", "-e", "-9", "compression/control")
-        xz("--compress", "-f", "-k", "-e", "-9", "compression/input.source")
-        xz("--compress", "-f", "-k", "-e", "-9", "compression/liberty.jpg")
+        _xz("--compress", "-f", "-k", "-e", "-9", "compression/text.html")
+        _xz("--compress", "-f", "-k", "-e", "-9", "compression/chicken.jpg")
+        _xz("--compress", "-f", "-k", "-e", "-9", "compression/control")
+        _xz("--compress", "-f", "-k", "-e", "-9", "compression/input.source")
+        _xz("--compress", "-f", "-k", "-e", "-9", "compression/liberty.jpg")
 
         # Decompress
-        xz("--decompress", "-f", "-k", "compression/text.html.xz")
-        xz("--decompress", "-f", "-k", "compression/chicken.jpg.xz")
-        xz("--decompress", "-f", "-k", "compression/control.xz")
-        xz("--decompress", "-f", "-k", "compression/input.source.xz")
-        xz("--decompress", "-f", "-k", "compression/liberty.jpg.xz")
+        _xz("--decompress", "-f", "-k", "compression/text.html.xz")
+        _xz("--decompress", "-f", "-k", "compression/chicken.jpg.xz")
+        _xz("--decompress", "-f", "-k", "compression/control.xz")
+        _xz("--decompress", "-f", "-k", "compression/input.source.xz")
+        _xz("--decompress", "-f", "-k", "compression/liberty.jpg.xz")

--- a/benchbuild/projects/lnt/lnt.py
+++ b/benchbuild/projects/lnt/lnt.py
@@ -57,12 +57,12 @@ class LNTGroup(project.Project):
         self.clang = compiler.cc(self, detect_project=True)
         self.clang_cxx = compiler.cxx(self, detect_project=True)
 
-        runtest = run.watch(self.lnt)
-        runtest("runtest", "test-suite", "-v", "-j1", "--sandbox",
-                self.sandbox_dir, "--benchmarking-only",
-                "--only-compile", "--cc", str(self.clang), "--cxx",
-                str(self.clang_cxx), "--test-suite", self.test_suite_dir,
-                "--only-test=" + self.SUBDIR)
+        _runtest = run.watch(self.lnt)
+        _runtest("runtest", "test-suite", "-v", "-j1", "--sandbox",
+                 self.sandbox_dir, "--benchmarking-only",
+                 "--only-compile", "--cc", str(self.clang), "--cxx",
+                 str(self.clang_cxx), "--test-suite", self.test_suite_dir,
+                 "--only-test=" + self.SUBDIR)
 
     @staticmethod
     def after_run_tests(sandbox_dir):
@@ -76,13 +76,13 @@ class LNTGroup(project.Project):
                                        "lnt_runner",
                                        name_filters=LNTGroup.NAME_FILTERS)
 
-        runtest = run.watch(self.lnt)
-        runtest("runtest", "nt", "-v", "-j1", "--sandbox", self.sandbox_dir,
-                "--benchmarking-only", "--cc", str(self.clang), "--cxx",
-                str(self.clang_cxx), "--test-suite", self.test_suite_dir,
-                "--test-style", "simple", "--test-externals", self.builddir,
-                "--make-param=RUNUNDER=" + str(binary),
-                "--only-test=" + self.SUBDIR)
+        _runtest = run.watch(self.lnt)
+        _runtest("runtest", "nt", "-v", "-j1", "--sandbox", self.sandbox_dir,
+                 "--benchmarking-only", "--cc", str(self.clang), "--cxx",
+                 str(self.clang_cxx), "--test-suite", self.test_suite_dir,
+                 "--test-style", "simple", "--test-externals", self.builddir,
+                 "--make-param=RUNUNDER=" + str(binary),
+                 "--only-test=" + self.SUBDIR)
 
         LNTGroup.after_run_tests(self.sandbox_dir)
 

--- a/benchbuild/projects/lnt/lnt.py
+++ b/benchbuild/projects/lnt/lnt.py
@@ -5,7 +5,7 @@ from plumbum import FG, local
 
 from benchbuild import project
 from benchbuild.settings import CFG
-from benchbuild.utils import compiler, download, wrapping
+from benchbuild.utils import compiler, download, run, wrapping
 from benchbuild.utils.cmd import cat, mkdir, rm, virtualenv
 
 LOG = logging.getLogger(__name__)
@@ -57,11 +57,12 @@ class LNTGroup(project.Project):
         self.clang = compiler.cc(self, detect_project=True)
         self.clang_cxx = compiler.cxx(self, detect_project=True)
 
-        self.lnt("runtest", "test-suite", "-v", "-j1", "--sandbox",
-                 self.sandbox_dir, "--benchmarking-only",
-                 "--only-compile", "--cc", str(self.clang), "--cxx",
-                 str(self.clang_cxx), "--test-suite", self.test_suite_dir,
-                 "--only-test=" + self.SUBDIR)
+        runtest = run.watch(self.lnt)
+        runtest("runtest", "test-suite", "-v", "-j1", "--sandbox",
+                self.sandbox_dir, "--benchmarking-only",
+                "--only-compile", "--cc", str(self.clang), "--cxx",
+                str(self.clang_cxx), "--test-suite", self.test_suite_dir,
+                "--only-test=" + self.SUBDIR)
 
     @staticmethod
     def after_run_tests(sandbox_dir):
@@ -70,18 +71,18 @@ class LNTGroup(project.Project):
             LOG.info("Dumping contents of: %s", log)
             (cat[log] & FG)  # pylint: disable=pointless-statement
 
-    def run_tests(self, runner):
-        binary = wrapping.wrap_dynamic(
-            self, "lnt_runner", name_filters=LNTGroup.NAME_FILTERS)
+    def run_tests(self):
+        binary = wrapping.wrap_dynamic(self,
+                                       "lnt_runner",
+                                       name_filters=LNTGroup.NAME_FILTERS)
 
-        runner(
-            self.lnt["runtest", "nt", "-v", "-j1", "--sandbox",
-                     self.sandbox_dir, "--benchmarking-only", "--cc",
-                     str(self.clang), "--cxx",
-                     str(self.clang_cxx), "--test-suite", self.test_suite_dir,
-                     "--test-style", "simple", "--test-externals",
-                     self.builddir, "--make-param=RUNUNDER=" +
-                     str(binary), "--only-test=" + self.SUBDIR])
+        runtest = run.watch(self.lnt)
+        runtest("runtest", "nt", "-v", "-j1", "--sandbox", self.sandbox_dir,
+                "--benchmarking-only", "--cc", str(self.clang), "--cxx",
+                str(self.clang_cxx), "--test-suite", self.test_suite_dir,
+                "--test-style", "simple", "--test-externals", self.builddir,
+                "--make-param=RUNUNDER=" + str(binary),
+                "--only-test=" + self.SUBDIR)
 
         LNTGroup.after_run_tests(self.sandbox_dir)
 

--- a/benchbuild/projects/polybench/polybench-mod.py
+++ b/benchbuild/projects/polybench/polybench-mod.py
@@ -39,10 +39,10 @@ class PolybenchModGroup(PolyBenchGroup):
             ], polybench_opts)
 
         clang = compiler.cc(self)
-        clang = run.watch(clang)
-        clang("-I", utils_dir, "-I", src_sub, polybench_opts,
-              utils_dir / "polybench.c", kernel_file, src_file, "-lm", "-o",
-              self.name)
+        _clang = run.watch(clang)
+        _clang("-I", utils_dir, "-I", src_sub, polybench_opts,
+               utils_dir / "polybench.c", kernel_file, src_file, "-lm", "-o",
+               self.name)
 
 
 class Correlation(PolybenchModGroup):

--- a/benchbuild/projects/polybench/polybench-mod.py
+++ b/benchbuild/projects/polybench/polybench-mod.py
@@ -39,9 +39,10 @@ class PolybenchModGroup(PolyBenchGroup):
             ], polybench_opts)
 
         clang = compiler.cc(self)
-        run.run(clang[
-            "-I", utils_dir, "-I", src_sub, polybench_opts, utils_dir /
-            "polybench.c", kernel_file, src_file, "-lm", "-o", self.name])
+        clang = run.watch(clang)
+        clang("-I", utils_dir, "-I", src_sub, polybench_opts,
+              utils_dir / "polybench.c", kernel_file, src_file, "-lm", "-o",
+              self.name)
 
 
 class Correlation(PolybenchModGroup):

--- a/benchbuild/projects/polybench/polybench.py
+++ b/benchbuild/projects/polybench/polybench.py
@@ -94,11 +94,12 @@ class PolyBenchGroup(project.Project):
         self.ldflags = []
 
         clang_no_opts = compiler.cc(self)
+        clang_no_opts = run.watch(clang_no_opts)
 
         self.cflags = cflags
         self.ldflags = ldflags
-        run.run(clang_no_opts[polybench_opts, compiler_args, "-o", self.name +
-                              ".no-opts", "-lm"])
+        clang_no_opts(polybench_opts, compiler_args, "-o",
+                      self.name + ".no-opts", "-lm")
         return polybench_opts
 
     def compile(self):
@@ -128,11 +129,11 @@ class PolyBenchGroup(project.Project):
                 src_file, "-lm"
             ], polybench_opts)
         clang = compiler.cc(self)
-        run.run(
-            clang["-I", utils_dir, "-I", src_sub, polybench_opts, utils_dir /
-                  "polybench.c", src_file, "-lm", "-o", self.name])
+        clang = run.watch(clang)
+        clang("-I", utils_dir, "-I", src_sub, polybench_opts,
+              utils_dir / "polybench.c", src_file, "-lm", "-o", self.name)
 
-    def run_tests(self, runner):
+    def run_tests(self):
         def filter_stderr(stderr_raw, stderr_filtered):
             """Extract dump_arrays_output from stderr."""
             with open(stderr_raw, 'r') as stderr:
@@ -147,7 +148,10 @@ class PolyBenchGroup(project.Project):
         opt_stderr_raw = binary + ".stderr"
         opt_stderr_filtered = opt_stderr_raw + ".filtered"
 
-        runner(wrapping.wrap(binary, self))
+        polybench_bin = wrapping.wrap(binary, self)
+        polybench_bin = run.watch(polybench_bin)
+        polybench_bin()
+
         filter_stderr(opt_stderr_raw, opt_stderr_filtered)
 
         if verify:
@@ -156,11 +160,14 @@ class PolyBenchGroup(project.Project):
             noopt_stderr_filtered = noopt_stderr_raw + ".filtered"
 
             with local.env(BB_IS_BASELINE=True):
-                runner(wrapping.wrap(binary, self))
+                polybench_bin = wrapping.wrap(binary, self)
+                polybench_bin = run.watch(polybench_bin)
+                polybench_bin()
             filter_stderr(noopt_stderr_raw, noopt_stderr_filtered)
 
-            diff_cmd = diff[noopt_stderr_filtered, opt_stderr_filtered]
-            runner(diff_cmd, retcode=0)
+            diff_ = diff[noopt_stderr_filtered, opt_stderr_filtered]
+            diff_ = run.watch(diff_)
+            diff_(retcode=0)
 
 
 class Correlation(PolyBenchGroup):

--- a/benchbuild/projects/polybench/polybench.py
+++ b/benchbuild/projects/polybench/polybench.py
@@ -94,12 +94,12 @@ class PolyBenchGroup(project.Project):
         self.ldflags = []
 
         clang_no_opts = compiler.cc(self)
-        clang_no_opts = run.watch(clang_no_opts)
+        _clang_no_opts = run.watch(clang_no_opts)
 
         self.cflags = cflags
         self.ldflags = ldflags
-        clang_no_opts(polybench_opts, compiler_args, "-o",
-                      self.name + ".no-opts", "-lm")
+        _clang_no_opts(polybench_opts, compiler_args, "-o",
+                       self.name + ".no-opts", "-lm")
         return polybench_opts
 
     def compile(self):
@@ -129,9 +129,9 @@ class PolyBenchGroup(project.Project):
                 src_file, "-lm"
             ], polybench_opts)
         clang = compiler.cc(self)
-        clang = run.watch(clang)
-        clang("-I", utils_dir, "-I", src_sub, polybench_opts,
-              utils_dir / "polybench.c", src_file, "-lm", "-o", self.name)
+        _clang = run.watch(clang)
+        _clang("-I", utils_dir, "-I", src_sub, polybench_opts,
+               utils_dir / "polybench.c", src_file, "-lm", "-o", self.name)
 
     def run_tests(self):
         def filter_stderr(stderr_raw, stderr_filtered):
@@ -149,8 +149,8 @@ class PolyBenchGroup(project.Project):
         opt_stderr_filtered = opt_stderr_raw + ".filtered"
 
         polybench_bin = wrapping.wrap(binary, self)
-        polybench_bin = run.watch(polybench_bin)
-        polybench_bin()
+        _polybench_bin = run.watch(polybench_bin)
+        _polybench_bin()
 
         filter_stderr(opt_stderr_raw, opt_stderr_filtered)
 
@@ -161,13 +161,12 @@ class PolyBenchGroup(project.Project):
 
             with local.env(BB_IS_BASELINE=True):
                 polybench_bin = wrapping.wrap(binary, self)
-                polybench_bin = run.watch(polybench_bin)
-                polybench_bin()
+                _polybench_bin = run.watch(polybench_bin)
+                _polybench_bin()
             filter_stderr(noopt_stderr_raw, noopt_stderr_filtered)
 
-            diff_ = diff[noopt_stderr_filtered, opt_stderr_filtered]
-            diff_ = run.watch(diff_)
-            diff_(retcode=0)
+            _diff = run.watch(diff[noopt_stderr_filtered, opt_stderr_filtered])
+            _diff(retcode=0)
 
 
 class Correlation(PolyBenchGroup):

--- a/benchbuild/projects/test/test.py
+++ b/benchbuild/projects/test/test.py
@@ -23,13 +23,13 @@ int main(int argc, char **argv) {
             test_source.write(lines)
 
         clang = compiler.cxx(self)
-        clang = run.watch(clang)
-        clang(self.src_file, "-o", self.src_file + ".out")
+        _clang = run.watch(clang)
+        _clang(self.src_file, "-o", self.src_file + ".out")
 
     def run_tests(self):
         exp = wrapping.wrap(self.src_file + ".out", self)
-        exp = run.watch(exp)
-        exp()
+        _exp = run.watch(exp)
+        _exp()
 
 
 class TestProjectRuntimeFail(project.Project):
@@ -54,10 +54,10 @@ int main(int argc, char **argv) {
             test_source.write(lines)
 
         clang = compiler.cxx(self)
-        clang = run.watch(clang)
-        clang(self.src_file, "-o", self.src_file + ".out")
+        _clang = run.watch(clang)
+        _clang(self.src_file, "-o", self.src_file + ".out")
 
     def run_tests(self):
         exp = wrapping.wrap(self.src_file + ".out", self)
-        exp = run.watch(exp)
-        exp()
+        _exp = run.watch(exp)
+        _exp()

--- a/benchbuild/projects/test/test.py
+++ b/benchbuild/projects/test/test.py
@@ -1,7 +1,5 @@
 from benchbuild import project
-from benchbuild.utils import compiler
-from benchbuild.utils import run
-from benchbuild.utils import wrapping
+from benchbuild.utils import compiler, run, wrapping
 
 
 class TestProject(project.Project):
@@ -25,11 +23,13 @@ int main(int argc, char **argv) {
             test_source.write(lines)
 
         clang = compiler.cxx(self)
-        run.run(clang[self.src_file, "-o", self.src_file + ".out"])
+        clang = run.watch(clang)
+        clang(self.src_file, "-o", self.src_file + ".out")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         exp = wrapping.wrap(self.src_file + ".out", self)
-        runner(exp)
+        exp = run.watch(exp)
+        exp()
 
 
 class TestProjectRuntimeFail(project.Project):
@@ -54,8 +54,10 @@ int main(int argc, char **argv) {
             test_source.write(lines)
 
         clang = compiler.cxx(self)
-        run.run(clang[self.src_file, "-o", self.src_file + ".out"])
+        clang = run.watch(clang)
+        clang(self.src_file, "-o", self.src_file + ".out")
 
-    def run_tests(self, runner):
+    def run_tests(self):
         exp = wrapping.wrap(self.src_file + ".out", self)
-        runner(exp)
+        exp = run.watch(exp)
+        exp()

--- a/benchbuild/utils/container.py
+++ b/benchbuild/utils/container.py
@@ -146,7 +146,7 @@ def unpack(container, path):
         path: The location where the container is, that needs to be unpacked.
 
     """
-    from benchbuild.utils.run import run
+    from benchbuild.utils import run
     from benchbuild.utils.uchroot import no_args
 
     path = local.path(path)
@@ -173,7 +173,8 @@ def unpack(container, path):
         if not has_erlent:
             untar = uchroot[untar]
 
-        run(untar["--exclude=dev/*"])
+        untar = run.watch(untar)
+        untar("--exclude=dev/*")
         if not os.path.samefile(name, container.filename):
             rm(name)
         else:

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -306,13 +306,17 @@ def track_execution(cmd, project, experiment, **kwargs):
     runner.commit()
 
 
-def run(command, retcode=0):
+def watch(command):
     """Execute a plumbum command, depending on the user's settings.
 
     Args:
         command: The plumbumb command to execute.
     """
-    return command & TEE(retcode=retcode)
+    def f(*args, retcode=0):
+        final_command = command[args]
+        return final_command & TEE(retcode=retcode)
+
+    return f
 
 
 def with_env_recursive(cmd, **envvars):

--- a/benchbuild/utils/wrapping.py
+++ b/benchbuild/utils/wrapping.py
@@ -106,12 +106,12 @@ def wrap(name, project, sprefix=None, python=sys.executable):
     name_absolute = os.path.abspath(name)
     real_f = name_absolute + PROJECT_BIN_F_EXT
     if sprefix:
-        mv_ = run.watch(uchroot()["/bin/mv"])
-        mv_(strip_path_prefix(name_absolute, sprefix),
+        _mv = run.watch(uchroot()["/bin/mv"])
+        _mv(strip_path_prefix(name_absolute, sprefix),
             strip_path_prefix(real_f, sprefix))
     else:
-        mv_ = run.watch(mv)
-        mv(name_absolute, real_f)
+        _mv = run.watch(mv)
+        _mv(name_absolute, real_f)
 
     project_file = persist(project, suffix=".project")
 
@@ -135,8 +135,8 @@ def wrap(name, project, sprefix=None, python=sys.executable):
                 python=python,
             ))
 
-    chmod_ = run.watch(chmod)
-    chmod_("+x", name_absolute)
+    _chmod = run.watch(chmod)
+    _chmod("+x", name_absolute)
     return local[name_absolute]
 
 

--- a/benchbuild/utils/wrapping.py
+++ b/benchbuild/utils/wrapping.py
@@ -30,9 +30,9 @@ import dill
 from plumbum import local
 
 from benchbuild.settings import CFG
+from benchbuild.utils import run
 from benchbuild.utils.cmd import chmod, mv
 from benchbuild.utils.path import list_to_path
-from benchbuild.utils.run import run
 from benchbuild.utils.uchroot import no_llvm as uchroot
 
 PROJECT_BIN_F_EXT = ".bin"
@@ -106,11 +106,12 @@ def wrap(name, project, sprefix=None, python=sys.executable):
     name_absolute = os.path.abspath(name)
     real_f = name_absolute + PROJECT_BIN_F_EXT
     if sprefix:
-        run(uchroot()["/bin/mv",
-                      strip_path_prefix(name_absolute, sprefix),
-                      strip_path_prefix(real_f, sprefix)])
+        mv_ = run.watch(uchroot()["/bin/mv"])
+        mv_(strip_path_prefix(name_absolute, sprefix),
+            strip_path_prefix(real_f, sprefix))
     else:
-        run(mv[name_absolute, real_f])
+        mv_ = run.watch(mv)
+        mv(name_absolute, real_f)
 
     project_file = persist(project, suffix=".project")
 
@@ -134,7 +135,8 @@ def wrap(name, project, sprefix=None, python=sys.executable):
                 python=python,
             ))
 
-    run(chmod["+x", name_absolute])
+    chmod_ = run.watch(chmod)
+    chmod_("+x", name_absolute)
     return local[name_absolute]
 
 

--- a/doc-src/benchbuild.project.md
+++ b/doc-src/benchbuild.project.md
@@ -75,19 +75,19 @@ For example, if we want to wrap the ``myproject`` binary from the previous examp
 as follows:
 
 ```python
-from benchbuild.utils.wrapping import wrap
+from benchbuild.utils import run, wrapping
 
-def run_tests(self, runner):
-    wrapped = wrap("myproject", self)
-    runner(wrapped['--verbose', '--myflag'])
+def run_tests(self):
+    wrapped = wrapping.wrap('myproject', self)
+    wrapped = run.watch(wrapped)
+    wrapped('--verbose', '--myflag')
 ```
 
 Note, that you can add arbitrary flags to the wrapped binary, e.g., ``--verbose`` and ``--myflag``.
 The ``run_tests`` method of ``project`` provides 2 parameters.
-First, the composed run-time extension ``experiment``, which was configured by the experiment.
-Second, a ``runner``, which provides a unified way for benchbuild to control the output and execution
-of the wrapped binary.
-You should use it for all executions performed in ``run_tests``, but nothing will break horribly if you don't.
+The composed run-time extension of your experiment will be used for the wrapper (it is stored in the *_extension attribute of the project).
+By default, all shell commands will be run in the background. You can selectively watch the output of a command by wrapping it
+inside the ``runnable`` function.
 
 
 ## API Reference

--- a/docs/_sources/benchbuild.project.md.txt
+++ b/docs/_sources/benchbuild.project.md.txt
@@ -67,7 +67,6 @@ class MyProject(Project):
         clang("-O3", "-o", "myproject", SRC_FILE)
 ```
 
-
 ### Wrapping a Binary
 
 In addition to compilers we can also wrap arbitrary binaries with our runtime extension using the ``benchbuild.utils.wrapping``.
@@ -75,19 +74,19 @@ For example, if we want to wrap the ``myproject`` binary from the previous examp
 as follows:
 
 ```python
-from benchbuild.utils.wrapping import wrap
+from benchbuild.utils import run, wrapping
 
-def run_tests(self, runner):
-    wrapped = wrap("myproject", self)
-    runner(wrapped['--verbose', '--myflag'])
+def run_tests(self):
+    wrapped = wrapping.wrap('myproject', self)
+    wrapped = run.watch(wrapped)
+    wrapped('--verbose', '--myflag')
 ```
 
 Note, that you can add arbitrary flags to the wrapped binary, e.g., ``--verbose`` and ``--myflag``.
 The ``run_tests`` method of ``project`` provides 2 parameters.
-First, the composed run-time extension ``experiment``, which was configured by the experiment.
-Second, a ``runner``, which provides a unified way for benchbuild to control the output and execution
-of the wrapped binary.
-You should use it for all executions performed in ``run_tests``, but nothing will break horribly if you don't.
+The composed run-time extension of your experiment will be used for the wrapper (it is stored in the *_extension attribute of the project).
+By default, all shell commands will be run in the background. You can selectively watch the output of a command by wrapping it
+inside the ``runnable`` function.
 
 
 ## API Reference


### PR DESCRIPTION
Benchbuild so far recognizes two different experimentation modes: compilation
and runtime.
This limitation is quite arbitrary and with this commit we begin to lift this
limitation and provide the user more control over the experimentation "phases".

As a first step it is necessary to unify the API used for both phases.
Historically, we provided a 'runner' argument that redirected all program output
to benchbuild's stdout.
The compilation stage did not have this and simply imported the
benchbuild.utils.run::run function and used it directly (this was the same
function that was handed in by benchbuild ;-)).

With future commits in mind, we replace benchbuild.utils.run::run with a new
function wrapper that takes a command and returns a function that takes the
command arguments and desired return code (as before).
This removes a great deal of clutter from experiments that make heavy use of the
former 'runner' argument.

However, this requires a mechanical change to existing code. I decided to use a
hard break, because the process is straight-forward to implement. Future changes
that depend on it might(will) break in subtle ways, if we support the new and
the old way.

Changes necessary:

1. Check for the correct import, e.g.:
	 from benchbuild.utils.run import run

-> from bencubuild.utls import run

2. Change signature of <project>::run_tests.
   def run_tests(self, runner):

-> def run_tests(self):

3. Change usages of runner inside <project>::run_tests.
   runner(cmd["a","b"], retcode=1)

-> cmd_ = run.watch(cmd)
   cmd_("a", "b", retcode=1)

4. Change usages of the benchbuild.utils.run.run function
   run(cmd["a","b"], retcode=1)

-> cmd_ = run.watch(cmd)
   cmd_("a", "b", retcode=1)

These changes are fairly mechanical. However, we cannot easily determine the
correct locations to provide an automatic fix.