### PR TITLE
settings: remove setting for 'testdir'

### DIFF
--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -38,14 +38,6 @@ CFG = s.Configuration(
             "default":
             s.ConfigPath(os.path.join(os.getcwd(), "results"))
         },
-        "test_dir": {
-            "desc":
-            "Additional test inputs, required for (some) run-time tests."
-            "These can be obtained from the a different repo. Most "
-            "projects don't need it",
-            "default":
-            os.path.join(os.getcwd(), "testinputs")
-        },
         "tmp_dir": {
             "desc": "Temporary dir. This will be used for caching downloads.",
             "default": s.ConfigPath(os.path.join(os.getcwd(), "tmp"))


### PR DESCRIPTION
This will be unnecessary with container support.

Sidenote: It was only ever used for runtime tests with huge artifact files that were not available to download (SPEC2006 Benchmarking Suite).