### PR TITLE
F/introduce public api

### DIFF
--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -9,7 +9,6 @@ from plumbum import local, Path
 from . import experiments as __EXPERIMENTS__
 from . import projects as __PROJECTS__
 from . import reports as __REPORTS__
-from .downloads.base import BaseSource
 from .project import Project
 from .settings import CFG
 from .utils import compiler, download, run
@@ -31,7 +30,6 @@ watch = run.watch
 del local
 del sys
 del BaseCommand
-del BaseSource
 del Path
 del __EXPERIMENTS__
 del __PROJECTS__

--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -4,6 +4,9 @@ Public API of benchbuild.
 import sys
 from plumbum import local
 
+# Project utilities
+from benchbuild.project import populate
+
 from . import experiments as __EXPERIMENTS__
 from . import projects as __PROJECTS__
 from . import reports as __REPORTS__

--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -2,35 +2,44 @@
 Public API of benchbuild.
 """
 import sys
-from typing import Callable, Optional
-from plumbum.commands import BaseCommand
-from plumbum import local, Path
+from plumbum import local
 
 from . import experiments as __EXPERIMENTS__
 from . import projects as __PROJECTS__
 from . import reports as __REPORTS__
-from .project import Project
-from .settings import CFG
-from .utils import compiler, download, run
 from .utils import settings as __SETTINGS__
+
+# Export: Project
+from .project import Project
+
+# Export: Configuration
+from .settings import CFG
+
+# Export: compiler, download, run and wrapping modules
+from .utils import compiler, download, run
 from .utils import wrapping
 
-__EXPERIMENTS__.discover()
-__PROJECTS__.discover()
-__REPORTS__.discover()
-__SETTINGS__.setup_config(CFG)
+def __init__() -> None:
+    """Initialize all plugins and settings."""
+    __EXPERIMENTS__.discover()
+    __PROJECTS__.discover()
+    __REPORTS__.discover()
+    __SETTINGS__.setup_config(CFG)
 
+__init__()
+
+# Forwards to plumbum
 cwd = local.cwd
 env = local.env
 path = local.path
 
+# Wrapping / Execution utilities
 wrap = wrapping.wrap
 watch = run.watch
 
+# Clean the namespace
 del local
 del sys
-del BaseCommand
-del Path
 del __EXPERIMENTS__
 del __PROJECTS__
 del __REPORTS__

--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -1,13 +1,39 @@
 """
-Setup plugins.
+Public API of benchbuild.
 """
+import sys
+from typing import Callable, Optional
+from plumbum.commands import BaseCommand
+from plumbum import local, Path
+
 from . import experiments as __EXPERIMENTS__
 from . import projects as __PROJECTS__
 from . import reports as __REPORTS__
-from .settings import CFG as __CFG__
+from .downloads.base import BaseSource
+from .project import Project
+from .settings import CFG
+from .utils import compiler, download, run
 from .utils import settings as __SETTINGS__
+from .utils import wrapping
 
 __EXPERIMENTS__.discover()
 __PROJECTS__.discover()
 __REPORTS__.discover()
-__SETTINGS__.setup_config(__CFG__)
+__SETTINGS__.setup_config(CFG)
+
+cwd = local.cwd
+env = local.env
+path = local.path
+
+wrap = wrapping.wrap
+watch = run.watch
+
+del local
+del sys
+del BaseCommand
+del BaseSource
+del Path
+del __EXPERIMENTS__
+del __PROJECTS__
+del __REPORTS__
+del __SETTINGS__

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -1,7 +1,7 @@
 """Subcommand for project handling."""
 from plumbum import cli
 
-from benchbuild import project
+import benchbuild as bb
 from benchbuild.cli.main import BenchBuild
 
 
@@ -29,7 +29,7 @@ class BBProjectView(cli.Application):
         self.groups = groups
 
     def main(self, *projects):
-        print_projects(project.populate(projects, self.groups))
+        print_projects(bb.populate(projects, self.groups))
 
 
 def print_projects(projects=None):


### PR DESCRIPTION
Introduce a public set of APIs.

This is not a complete implementation as the brainwork that went into this was quite minimal.
However, it should be useful because we can keep the footprint of our imports low and provide a defined set of APIs that the end-user can expect to be more stable than the rest of benchbuild.

This needs to be fleshed out. Not sure if the maintenance overhead is worth it.