### PR TITLE
source: add accessor for the 'main' source of a project.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = attr,dill,migrate,pandas,pkg_resources,plumbum,psutil,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,urwid,yaml
+known_third_party = attr,dill,migrate,pandas,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,urwid,yaml

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -227,7 +227,7 @@ class Project(metaclass=ProjectDecorator):
     source: Sources = attr.ib(
         default=attr.Factory(lambda self: type(self).SOURCE, takes_self=True))
 
-    primary_source: str = attr.ib(init=False)
+    primary_source: str = attr.ib()
 
     @primary_source.default
     def __default_primary_source(self) -> str:

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -230,7 +230,7 @@ class Project(metaclass=ProjectDecorator):
     primary_source: source.BaseSource = attr.ib(init=False)
 
     @primary_source.default
-    def __default_primary_source(self) -> str:  # pylint: disable=no-self-use
+    def __default_primary_source(self) -> str:
         return source.primary(*self.source).key
 
     compiler_extension = attr.ib(

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -227,6 +227,12 @@ class Project(metaclass=ProjectDecorator):
     source: Sources = attr.ib(
         default=attr.Factory(lambda self: type(self).SOURCE, takes_self=True))
 
+    primary_source: source.BaseSource = attr.ib(init=False)
+
+    @primary_source.default
+    def __default_primary_source(self) -> str:  # pylint: disable=no-self-use
+        return source.primary(*self.source).key
+
     compiler_extension = attr.ib(
         default=attr.Factory(lambda self: ext_run.WithTimeout(
             compiler.RunCompiler(self, self.experiment)),

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -227,7 +227,7 @@ class Project(metaclass=ProjectDecorator):
     source: Sources = attr.ib(
         default=attr.Factory(lambda self: type(self).SOURCE, takes_self=True))
 
-    primary_source: source.BaseSource = attr.ib(init=False)
+    primary_source: str = attr.ib(init=False)
 
     @primary_source.default
     def __default_primary_source(self) -> str:

--- a/benchbuild/projects/gentoo/portage_gen.py
+++ b/benchbuild/projects/gentoo/portage_gen.py
@@ -6,6 +6,7 @@ import logging
 from plumbum import ProcessExecutionError, local
 
 from benchbuild.projects.gentoo import autoportage
+from benchbuild.source import nosource
 from benchbuild.utils import run, uchroot
 
 LOG = logging.getLogger(__name__)
@@ -108,7 +109,7 @@ def PortageFactory(name, NAME, DOMAIN, BaseClass=autoportage.AutoPortage):
         name, (BaseClass,), {
             "NAME": NAME,
             "DOMAIN": DOMAIN,
-            "SRC_FILE": "none",
+            "SOURCE": [nosource()],
             "GROUP": "auto-gentoo",
             "run": run_not_supported,
             "__module__": "__main__"

--- a/benchbuild/projects/test/test.py
+++ b/benchbuild/projects/test/test.py
@@ -1,5 +1,6 @@
 import benchbuild as bb
 from benchbuild import project
+from benchbuild.source import nosource
 
 
 class TestProject(project.Project):
@@ -7,6 +8,7 @@ class TestProject(project.Project):
     NAME = "test"
     DOMAIN = "test"
     GROUP = "test"
+    SOURCE = [nosource()]
 
     def compile(self):
         with open('test.cpp', 'w') as test_source:
@@ -37,6 +39,7 @@ class TestProjectRuntimeFail(project.Project):
     DOMAIN = "test"
     GROUP = "test"
     SRC_FILE = "test.cpp"
+    SOURCE = [nosource()]
 
     def compile(self):
         with open('test.cpp', 'w') as test_source:

--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -7,8 +7,8 @@ from .base import Variant as Variant
 from .base import VariantContext as VariantContext
 from .base import context as context
 from .base import default as default
-from .base import main as main
 from .base import nosource as nosource
+from .base import primary as primary
 from .base import product as product
 from .base import to_str as to_str
 from .git import Git as Git

--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -7,6 +7,7 @@ from .base import Variant as Variant
 from .base import VariantContext as VariantContext
 from .base import context as context
 from .base import default as default
+from .base import main as main
 from .base import nosource as nosource
 from .base import product as product
 from .base import to_str as to_str

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -195,6 +195,20 @@ def default(*sources: BaseSource) -> VariantContext:
     return context(*first)
 
 
+def main(source: BaseSource, *sources: BaseSource) -> BaseSource:
+    """
+    Return the implicit 'main' source of a project.
+
+    We define the main source as the first source listed in a project.
+
+    If you define a new project and rely on the existence of a 'main'
+    source code repository, make sure to define it as the first one.
+    """
+    del sources
+
+    return source
+
+
 def product(*sources: BaseSource) -> NestedVariants:
     """
     Return the cross product of the given sources.

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -195,7 +195,7 @@ def default(*sources: BaseSource) -> VariantContext:
     return context(*first)
 
 
-def main(source: BaseSource, *sources: BaseSource) -> BaseSource:
+def primary(source: BaseSource, *sources: BaseSource) -> BaseSource:
     """
     Return the implicit 'main' source of a project.
 

--- a/tests/test_213_error_tracking.py
+++ b/tests/test_213_error_tracking.py
@@ -8,6 +8,7 @@ from plumbum import ProcessExecutionError
 
 from benchbuild import experiment
 from benchbuild import project as prj
+from benchbuild.source import nosource
 from benchbuild.utils import actions as a
 from benchbuild.utils import tasks
 
@@ -32,13 +33,14 @@ class Issue213b(a.Step):
         return a.StepResult.ERROR
 
 
+@attr.s
 class EmptyProject(prj.Project):
     """An empty project that serves as an empty shell for testing."""
 
     NAME = "test_empty"
     DOMAIN = "debug"
     GROUP = "debug"
-    SRC_FILE = "none"
+    SOURCE = [nosource()]
 
     def compile(self):
         pass

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -7,6 +7,7 @@ from plumbum import ProcessExecutionError
 
 from benchbuild.experiment import Experiment
 from benchbuild.project import Project
+from benchbuild.source import nosource
 from benchbuild.utils import actions as a
 
 
@@ -14,7 +15,7 @@ class EmptyProject(Project):
     NAME = "test_empty"
     DOMAIN = "debug"
     GROUP = "debug"
-    SRC_FILE = "none"
+    SOURCE = [nosource()]
 
     def build(self):
         pass


### PR DESCRIPTION
This adds support for the 'main' source of a project. By default
this should be the first project listed in a project.

This holds for all existing benchbuild project's and should hold for all
known sources in other projects.

Example usage:
  >>> main(*[1,2,3])
  1