### PR TITLE
project: add shortcut attributes for primary_source

### DIFF
--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -349,6 +349,26 @@ class Project(metaclass=ProjectDecorator):
             return str(variant[name])
         return None
 
+    @property
+    def version_of_primary(self) -> str:
+        """
+        Get version of the primary source.
+        """
+        version_str = self.version_of(self.primary_source)
+        if not version_str:
+            raise ValueError('You are expected to have a primary_source.')
+        return version_str
+
+    @property
+    def source_of_primary(self) -> str:
+        """
+        Get source of the primary source.
+        """
+        source_str = self.source_of(self.primary_source)
+        if not source_str:
+            raise ValueError('You are expected to have a primary_source.')
+        return source_str
+
 
 def __split_project_input__(
         project_input: str) -> tp.Tuple[str, tp.Optional[str]]:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,58 @@
+# pylint: disable=redefined-outer-name
+import attr
+import pytest
+from plumbum import local
+
+from benchbuild import Project
+from benchbuild.source import nosource
+
+
+class DummyPrj(Project):
+    NAME = 'TestPrj'
+    DOMAIN = 'TestDom'
+    GROUP = 'TestGrp'
+    SOURCE = [nosource()]
+
+    def run_tests(self):
+        raise NotImplementedError()
+
+
+class DummyPrjEmptySource(Project):
+    NAME = 'TestPrj'
+    DOMAIN = 'TestDom'
+    GROUP = 'TestGrp'
+    SOURCE = []
+
+    def run_tests(self):
+        raise NotImplementedError()
+
+
+@pytest.fixture
+def dummy_exp():
+    return attr.make_class('TestExp', {'name': attr.ib(default='TestExp')})
+
+
+def test_attr_version_of(dummy_exp):
+    prj = DummyPrj(experiment=dummy_exp())
+    assert hasattr(prj, 'version_of_primary')
+
+
+def test_attr_source_of(dummy_exp):
+    prj = DummyPrj(experiment=dummy_exp())
+    assert hasattr(prj, 'source_of_primary')
+
+
+def test_version_of_primary(dummy_exp):
+    prj = DummyPrj(experiment=dummy_exp())
+    assert prj.version_of_primary == 'None'
+
+
+def test_source_of_primary(dummy_exp):
+    prj = DummyPrj(experiment=dummy_exp())
+    assert local.path(prj.source_of_primary).name == 'NoSource'
+
+
+def test_primary_source(dummy_exp):
+    with pytest.raises(TypeError) as excinfo:
+        DummyPrjEmptySource(experiment=dummy_exp())
+    assert "primary()" in str(excinfo)


### PR DESCRIPTION
This adds two convenience-wrappers for dealing with primary_source:
  * version_of_primary
  * source_of_primary

Both provide a convenient wrapper for the pattern:
  ``self.{source,version}_of_primary(self.primary_source)``