### PR TITLE
utils/actions: switch from multiprocessing to pathos

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = attr,dill,migrate,pandas,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,urwid,yaml
+known_third_party = attr,dill,migrate,pandas,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,urwid,yaml

--- a/benchbuild/utils/actions.py
+++ b/benchbuild/utils/actions.py
@@ -16,7 +16,6 @@ import enum
 import functools as ft
 import itertools
 import logging
-import multiprocessing as mp
 import os
 import sys
 import textwrap
@@ -25,6 +24,7 @@ import typing as tp
 from datetime import datetime
 
 import attr
+import pathos.multiprocessing as mp
 import sqlalchemy as sa
 from plumbum import ProcessExecutionError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ attrs~=19.3
 dill~=0.3
 pandas~=1.0
 parse~=1.15
+pathos~=0.2
 pdoc3~=0.8
 plumbum~=1.6
 psutil~=5.7

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ setup(name='benchbuild',
       tests_require=["pytest"],
       install_requires=[
           "Jinja2~=2.10", "PyYAML~=5.1", "attrs~=19.3", "dill~=0.3",
-          "pandas>=0.25,<2.0", "parse~=1.14", "pdoc3~=0.8", "plumbum~=1.6",
-          "psutil~=5.6", "psycopg2-binary~=2.8", "pygit2>=1.2","pygtrie~=2.3",
-          "pyparsing~=2.4", "sqlalchemy-migrate~=0.13", "urwid~=2.1",
-          "virtualenv>=16.7,<21.0"
+          "pandas>=0.25,<2.0", "parse~=1.14", "pathos~=0.2", "pdoc3~=0.8",
+          "plumbum~=1.6", "psutil~=5.6", "psycopg2-binary~=2.8", "pygit2>=1.2",
+          "pygtrie~=2.3", "pyparsing~=2.4", "sqlalchemy-migrate~=0.13",
+          "urwid~=2.1", "virtualenv>=16.7,<21.0"
       ],
       author="Andreas Simbuerger",
       author_email="simbuerg@fim.uni-passau.de",


### PR DESCRIPTION
pathos.multiprocessing replaces python's own multiprocessing module. We need
this to be able to take advantage of dill when running functions within a
mp.Pool.