### PR TITLE
utils/slurm: fix missing sample function.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = attr,dill,migrate,pandas,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,yaml
+known_third_party = attr,dill,migrate,pandas,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,yaml

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = attr,dill,migrate,pandas,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,yaml
+known_third_party = attr,dill,migrate,pandas,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,setuptools,six,sqlalchemy,yaml

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -221,7 +221,7 @@ class Project(metaclass=ProjectDecorator):
             raise TypeError("{attribute} must be a valid UUID object")
 
     builddir: local.path = attr.ib(default=attr.Factory(lambda self: local.path(
-        str(CFG["build_dir"])) / self.experiment.name / self.id,
+        str(CFG["build_dir"])) / self.experiment.name / self.id / self.run_uuid,
                                                         takes_self=True))
 
     source: Sources = attr.ib(
@@ -305,7 +305,7 @@ class Project(metaclass=ProjectDecorator):
     @property
     def id(self) -> str:
         version_str = source.to_str(*tuple(self.variant.values()))
-        return f"{self.name}/{self.group}/{version_str}/{self.run_uuid}"
+        return f'{self.name}-{self.group}@{version_str}'
 
     def prepare(self) -> None:
         """Prepare the build diretory."""

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -433,10 +433,16 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
     if not project.SOURCE:
         return project
 
-    if isinstance(version_in, str):
+    def csv(in_str: str) -> bool:
+        return len(in_str.split(',')) > 1
+
+    is_csv = csv(version_in)
+
+    if isinstance(version_in, str) and not is_csv:
         return __add_single_filter__(project, version_in)
 
-    if isinstance(version_in, list):
+    if isinstance(version_in, list) or is_csv:
+        version_in = version_in.split(',') if is_csv else version_in
         return __add_indexed_filters__(project, version_in)
 
     if isinstance(version_in, dict):

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -59,8 +59,10 @@ class ProjectRegistry(type):
                             for attr in ['NAME', 'DOMAIN', 'GROUP'])
 
         if bases and defined_attrs:
-            key = "{name}/{group}".format(name=cls.NAME, group=cls.GROUP)
+            key = f"{cls.NAME}/{cls.GROUP}"
+            key_dash = f"{cls.NAME}-{cls.GROUP}"
             ProjectRegistry.projects[key] = cls
+            ProjectRegistry.projects[key_dash] = cls
         return cls
 
 

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -436,7 +436,9 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
         return project
 
     def csv(in_str: str) -> bool:
-        return len(in_str.split(',')) > 1
+        if isinstance(in_str, str):
+            return len(in_str.split(',')) > 1
+        return False
 
     is_csv = csv(version_in)
 

--- a/benchbuild/utils/__init__.py
+++ b/benchbuild/utils/__init__.py
@@ -57,7 +57,7 @@ class CommandAlias(ModuleType):
         if command in self.__overrides__:
             check = self.__overrides__[command]
 
-        check = __ALIASES__.get(command, [command])
+        check.extend(__ALIASES__.get(command, [command]))
 
         env = CFG["env"].value
         path = path_to_list(getenv("PATH", ""))

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -15,7 +15,6 @@ from plumbum import TF, local
 
 from benchbuild.experiment import Experiment
 from benchbuild.settings import CFG
-from benchbuild.source import to_str
 from benchbuild.utils.cmd import bash, chmod
 from benchbuild.utils.path import list_to_path
 from benchbuild.utils.requirements import (get_slurm_options_from_config,

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -15,6 +15,7 @@ from plumbum import TF, local
 
 from benchbuild.experiment import Experiment
 from benchbuild.settings import CFG
+from benchbuild.source import to_str
 from benchbuild.utils.cmd import bash, chmod
 from benchbuild.utils.path import list_to_path
 from benchbuild.utils.requirements import (get_slurm_options_from_config,
@@ -54,12 +55,10 @@ def __expand_project_versions__(experiment: Experiment) -> Iterable[str]:
     expanded = []
 
     for _, project_type in project_types.items():
-        for version in experiment.sample(project_type, project_type.versions()):
-            project = project_type(experiment, version=version)
-            expanded.append(
-                "{name}-{group}@{version}".format(name=project.name,
-                                                  group=project.group,
-                                                  version=project.version))
+        for variant in experiment.sample(project_type):
+            project = project_type(experiment, variant=variant)
+            version = to_str(project.variant)
+            expanded.append(f'{project.name}-{project.group}@{version}')
     return expanded
 
 

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -57,8 +57,7 @@ def __expand_project_versions__(experiment: Experiment) -> Iterable[str]:
     for _, project_type in project_types.items():
         for variant in experiment.sample(project_type):
             project = project_type(experiment, variant=variant)
-            version = to_str(project.variant)
-            expanded.append(f'{project.name}-{project.group}@{version}')
+            expanded.append(project.id)
     return expanded
 
 

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -15,6 +15,7 @@ from plumbum import TF, local
 
 from benchbuild.experiment import Experiment
 from benchbuild.settings import CFG
+from benchbuild.utils import cmd
 from benchbuild.utils.cmd import bash, chmod
 from benchbuild.utils.path import list_to_path
 from benchbuild.utils.requirements import (get_slurm_options_from_config,
@@ -36,7 +37,7 @@ def script(experiment):
     slurm_script = local.cwd / experiment.name + "-" + str(
         CFG['slurm']['script'])
 
-    srun = local["srun"]
+    srun = cmd["srun"]
     srun_args = []
     if not CFG["slurm"]["multithread"]:
         srun_args.append("--hint=nomultithread")

--- a/tests/experiments/test_discovery.py
+++ b/tests/experiments/test_discovery.py
@@ -1,19 +1,25 @@
 import logging
 
+from benchbuild.experiment import ExperimentRegistry
 from benchbuild.experiments import discover
 from benchbuild.settings import CFG
 
 
 def test_discovery(caplog):
     caplog.set_level(logging.DEBUG, logger='benchbuild')
-    CFG["plugins"]["experiments"] = [
+    CFG['plugins']['experiments'] = [
         "benchbuild.non.existing", "benchbuild.reports.raw"
     ]
-    discover()
 
+    discover()
     assert caplog.record_tuples == [
         ('benchbuild.experiments', logging.ERROR,
          "Could not find 'benchbuild.non.existing'"),
         ('benchbuild.experiments', logging.ERROR,
          "ImportError: No module named 'benchbuild.non'"),
     ]
+
+    default = CFG['plugins']['experiments'].node['default']
+    CFG['plugins']['experiments'] = default
+
+    discover()

--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -7,6 +7,6 @@ from benchbuild.cli.slurm import Slurm
 def test_slurm_command(tmp_path):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with local.cwd(tmp_path):
-            Slurm.run(argv=['slurm', '-E', 'raw', 'test'])
+            Slurm.run(argv=['slurm', '-E', 'empty', 'test'])
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 0

--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -1,0 +1,12 @@
+import pytest
+from plumbum import local
+
+from benchbuild.cli.slurm import Slurm
+
+
+def test_slurm_command(tmp_path):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        with local.cwd(tmp_path):
+            Slurm.run(argv=['slurm', '-E', 'raw', 'test'])
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 0

--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -1,12 +1,25 @@
+import typing as tp
+
 import pytest
 from plumbum import local
 
 from benchbuild.cli.slurm import Slurm
-from benchbuild.experiment import ExperimentRegistry
-from benchbuild.settings import CFG
+from benchbuild.utils import cmd
 
 
-def test_slurm_command(tmp_path):
+@pytest.fixture
+def cmd_mock() -> tp.Callable[[str], None]:
+
+    def _cmd_mock(name: str):
+        cmd.__overrides__[name] = ['/bin/true']
+
+    yield _cmd_mock
+    cmd.__overrides__ = []
+
+
+def test_slurm_command(tmp_path, cmd_mock):
+    cmd_mock('srun')
+
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with local.cwd(tmp_path):
             Slurm.run(argv=['slurm', '-E', 'empty', 'test'])

--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -1,10 +1,16 @@
 import pytest
 from plumbum import local
+from rich import print
 
 from benchbuild.cli.slurm import Slurm
+from benchbuild.experiment import ExperimentRegistry
+from benchbuild.settings import CFG
 
 
 def test_slurm_command(tmp_path):
+    print(CFG['plugins']['experiments'])
+
+    print(ExperimentRegistry.experiments.items())
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with local.cwd(tmp_path):
             Slurm.run(argv=['slurm', '-E', 'empty', 'test'])

--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -1,6 +1,5 @@
 import pytest
 from plumbum import local
-from rich import print
 
 from benchbuild.cli.slurm import Slurm
 from benchbuild.experiment import ExperimentRegistry
@@ -8,9 +7,6 @@ from benchbuild.settings import CFG
 
 
 def test_slurm_command(tmp_path):
-    print(CFG['plugins']['experiments'])
-
-    print(ExperimentRegistry.experiments.items())
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with local.cwd(tmp_path):
             Slurm.run(argv=['slurm', '-E', 'empty', 'test'])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+import copy
 import typing as tp
 
 import pytest
@@ -24,8 +25,10 @@ def empty_compile(prj: Project) -> None:
 
 @pytest.fixture
 def registry():
+    restore = copy.deepcopy(ExperimentRegistry.experiments)
     ExperimentRegistry.experiments.clear()
-    return ExperimentRegistry
+    yield ExperimentRegistry
+    ExperimentRegistry.experiments = restore
 
 
 @pytest.fixture


### PR DESCRIPTION
This migrates the sample function of experiments over to declarative
sources. This was missing from the declarative sources PR.

Existing overrides have to adapt to the new API. Behavior similar to the
old sample() can be achieved by doing something like this:
 1. Create a list of Variants for the primary source, e.g.:
    source.primary(prj_cls.SOURCE).versions()
 2. Sample the list of variants (use your existing code to filter a list
    of version strings, Variants behave like a str.
 3. Convert the list of Variants into a list of VariantContext objects,
    e.g. [source.context(var) for var in variants]
 4. Return the list of VariantContexts

Still requires more elaborate tests.