### PR TITLE
F/unify plugins

### DIFF
--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -10,9 +10,7 @@ import plumbum as pb
 from benchbuild.project import populate as populate
 
 # Export: Source Code handling
-from . import experiments as __EXPERIMENTS__
-from . import projects as __PROJECTS__
-from . import reports as __REPORTS__
+from . import plugins as __PLUGINS__
 from . import source as source
 from .experiment import Experiment as Experiment
 # Export: Project
@@ -32,9 +30,7 @@ from .utils.wrapping import wrap as wrap
 
 def __init__() -> None:
     """Initialize all plugins and settings."""
-    __EXPERIMENTS__.discover()
-    __PROJECTS__.discover()
-    __REPORTS__.discover()
+    __PLUGINS__.discover()
     __SETTINGS__.setup_config(CFG)
 
 
@@ -48,7 +44,5 @@ path = pb.local.path
 # Clean the namespace
 del sys
 del pb
-del __EXPERIMENTS__
-del __PROJECTS__
-del __REPORTS__
+del __PLUGINS__
 del __SETTINGS__

--- a/benchbuild/cli/experiment.py
+++ b/benchbuild/cli/experiment.py
@@ -2,7 +2,7 @@
 import sqlalchemy as sa
 from plumbum import cli
 
-from benchbuild import experiment, experiments
+from benchbuild import experiment, plugins
 from benchbuild.cli.main import BenchBuild
 from benchbuild.utils import schema
 
@@ -21,8 +21,7 @@ class BBExperimentView(cli.Application):
     """View available experiments."""
 
     def main(self):
-        experiments.discover()
-        all_exps = experiment.ExperimentRegistry.experiments
+        all_exps = experiment.discovered()
         for exp_cls in all_exps.values():
             print(exp_cls.NAME)
             docstring = exp_cls.__doc__ or "-- no docstring --"

--- a/benchbuild/cli/experiment.py
+++ b/benchbuild/cli/experiment.py
@@ -2,7 +2,7 @@
 import sqlalchemy as sa
 from plumbum import cli
 
-from benchbuild import experiment, plugins
+from benchbuild import experiment
 from benchbuild.cli.main import BenchBuild
 from benchbuild.utils import schema
 

--- a/benchbuild/cli/main.py
+++ b/benchbuild/cli/main.py
@@ -17,20 +17,22 @@ class BenchBuild(cli.Application):
     debug = cli.Flag('-d', help="Enable debugging output")
 
     def main(self, *args):
+        cfg = settings.CFG
+
         self.verbosity = self.verbosity if self.verbosity < 6 else 5
         if self.debug:
             self.verbosity = 3
         verbosity = int(os.getenv('BB_VERBOSITY', self.verbosity))
 
-        settings.CFG["verbosity"] = verbosity
-        settings.CFG["debug"] = self.debug
+        cfg["verbosity"] = verbosity
+        cfg["debug"] = self.debug
 
         log.configure()
         log.set_defaults()
 
         plugins.discover()
 
-        if CFG["db"]["create_functions"]:
+        if cfg["db"]["create_functions"]:
             from benchbuild.utils.schema import init_functions, Session
             init_functions(Session())
 

--- a/benchbuild/cli/main.py
+++ b/benchbuild/cli/main.py
@@ -3,7 +3,7 @@ import os
 
 from plumbum import cli
 
-from benchbuild import settings
+from benchbuild import plugins, settings
 from benchbuild.utils import log
 
 
@@ -28,7 +28,9 @@ class BenchBuild(cli.Application):
         log.configure()
         log.set_defaults()
 
-        if settings.CFG["db"]["create_functions"]:
+        plugins.discover()
+
+        if CFG["db"]["create_functions"]:
             from benchbuild.utils.schema import init_functions, Session
             init_functions(Session())
 

--- a/benchbuild/cli/report.py
+++ b/benchbuild/cli/report.py
@@ -1,6 +1,6 @@
 from plumbum import cli
 
-from benchbuild import experiments, reports
+from benchbuild import plugins, reports
 from benchbuild.cli.main import BenchBuild
 from benchbuild.utils import schema
 
@@ -44,9 +44,8 @@ class BenchBuildReport(cli.Application):
     def main(self, *args):
         del args  # Unused
 
-        experiments.discover()
-        reports.discover()
-        all_reports = reports.ReportRegistry.reports
+        plugins.discover()
+        all_reports = reports.discovered()
 
         def generate_reports(_reports, _experiments=None):
             if not reports:

--- a/benchbuild/cli/run.py
+++ b/benchbuild/cli/run.py
@@ -11,7 +11,7 @@ import time
 
 from plumbum import cli
 
-from benchbuild import engine, experiment, experiments, project
+from benchbuild import engine, experiment, plugins, project
 from benchbuild.cli.main import BenchBuild
 from benchbuild.settings import CFG
 
@@ -57,8 +57,8 @@ class BenchBuildRun(cli.Application):
         experiment_names = self.experiment_names
         group_names = self.group_names
 
-        experiments.discover()
-        all_exps = experiment.ExperimentRegistry.experiments
+        plugins.discover()
+        all_exps = experiment.discovered()
 
         if self.test_full:
             exps = all_exps

--- a/benchbuild/cli/slurm.py
+++ b/benchbuild/cli/slurm.py
@@ -51,7 +51,7 @@ class Slurm(cli.Application):
         """Run a group of projects under the given experiments"""
         self._group_names = groups
 
-    def main(self, *projects):
+    def main(self, *projects: str) -> None:
         """Main entry point of benchbuild run."""
         exp = [self._experiment]
         group_names = self._group_names
@@ -76,7 +76,7 @@ class Slurm(cli.Application):
                   ' in the experiment registry.')
             sys.exit(1)
 
-        prjs = project.populate(projects, group_names)
+        prjs = project.populate(list(projects), group_names)
         for exp_cls in exps.values():
             exp = exp_cls(projects=prjs)
             print("Experiment: ", exp.name)

--- a/benchbuild/cli/slurm.py
+++ b/benchbuild/cli/slurm.py
@@ -11,10 +11,7 @@ import sys
 
 from plumbum import cli
 
-import benchbuild.experiment
-import benchbuild.experiments
-import benchbuild.project
-import benchbuild.projects
+from benchbuild import experiment, plugins, project
 from benchbuild.cli.main import BenchBuild
 from benchbuild.settings import CFG
 from benchbuild.utils import slurm
@@ -59,10 +56,9 @@ class Slurm(cli.Application):
         exp = [self._experiment]
         group_names = self._group_names
 
-        benchbuild.experiments.discover()
-        benchbuild.projects.discover()
+        plugins.discover()
 
-        all_exps = benchbuild.experiment.ExperimentRegistry.experiments
+        all_exps = experiment.discovered()
 
         if self._description:
             CFG["experiment_description"] = self._description
@@ -80,7 +76,7 @@ class Slurm(cli.Application):
                   ' in the experiment registry.')
             sys.exit(1)
 
-        prjs = benchbuild.project.populate(projects, group_names)
+        prjs = project.populate(projects, group_names)
         for exp_cls in exps.values():
             exp = exp_cls(projects=prjs)
             print("Experiment: ", exp.name)

--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -225,3 +225,8 @@ class Configuration:
 
     def __add__(self, rhs):
         self.config.update(rhs.config)
+
+
+def discovered() -> tp.Dict[str, Experiment]:
+    """Return all discovered experiments."""
+    return ExperimentRegistry.experiments

--- a/benchbuild/plugins.py
+++ b/benchbuild/plugins.py
@@ -34,6 +34,7 @@ def discover():
                                       report_plugins):
             try:
                 importlib.import_module(plugin)
+                LOG.info('Found report: %s', str(plugin))
             except ImportError as import_error:
-                LOG.error("Could not find '%s'", plugin)
-                LOG.error("ImportError: %s", import_error.msg)
+                LOG.error("Could not find '%s'", import_error.name)
+                LOG.debug("ImportError: %s", import_error.msg)

--- a/benchbuild/plugins.py
+++ b/benchbuild/plugins.py
@@ -14,9 +14,9 @@ Any subclass of
 will automatically register itself and is available on the CLI for all
 subcommands.
 """
-import logging
 import importlib
 import itertools
+import logging
 
 from benchbuild.settings import CFG
 
@@ -34,7 +34,6 @@ def discover():
                                       report_plugins):
             try:
                 importlib.import_module(plugin)
-                LOG.error(plugin)
             except ImportError as import_error:
                 LOG.error("Could not find '%s'", plugin)
                 LOG.error("ImportError: %s", import_error.msg)

--- a/benchbuild/plugins.py
+++ b/benchbuild/plugins.py
@@ -1,0 +1,40 @@
+"""
+Support a light plugin infrastructure.
+
+We dynamically load all modules listed in benchbuilds plugin configuration.
+*_PLUGINS_{EXPERIMENTS,PROJECTS}. See benchbuild's default settings for more
+details.
+
+Autoloading of plugins requires the configuration option BB_PLUGINS_AUTOLOAD
+to be set to True.
+
+Any subclass of
+    - benchbuild.experiment.Experiment
+    - benchbuild.project.Project
+will automatically register itself and is available on the CLI for all
+subcommands.
+"""
+import logging
+import importlib
+import itertools
+
+from benchbuild.settings import CFG
+
+LOG = logging.getLogger(__name__)
+
+
+def discover():
+    """Import all plugins listed in our configuration."""
+    if CFG["plugins"]["autoload"]:
+        experiment_plugins = CFG["plugins"]["experiments"].value
+        project_plugins = CFG["plugins"]["projects"].value
+        report_plugins = CFG["plugins"]["reports"].value
+
+        for plugin in itertools.chain(experiment_plugins, project_plugins,
+                                      report_plugins):
+            try:
+                importlib.import_module(plugin)
+                LOG.error(plugin)
+            except ImportError as import_error:
+                LOG.error("Could not find '%s'", plugin)
+                LOG.error("ImportError: %s", import_error.msg)

--- a/benchbuild/plugins.py
+++ b/benchbuild/plugins.py
@@ -23,7 +23,7 @@ from benchbuild.settings import CFG
 LOG = logging.getLogger(__name__)
 
 
-def discover():
+def discover() -> None:
     """Import all plugins listed in our configuration."""
     if CFG["plugins"]["autoload"]:
         experiment_plugins = CFG["plugins"]["experiments"].value
@@ -37,4 +37,4 @@ def discover():
                 LOG.info('Found report: %s', str(plugin))
             except ImportError as import_error:
                 LOG.error("Could not find '%s'", import_error.name)
-                LOG.debug("ImportError: %s", import_error.msg)
+                LOG.debug("ImportError: %s", import_error)

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -383,7 +383,7 @@ def __split_project_input__(
 
 def discovered() -> tp.Dict[str, Project]:
     """Return all discovered projects."""
-    return ProjectRegistry.projects
+    return dict(ProjectRegistry.projects)
 
 
 def __add_single_filter__(project: ProjectT, version: str) -> ProjectT:

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -381,7 +381,7 @@ def __split_project_input__(
     return (first, second)
 
 
-def discovered() -> Dict[str, Project]:
+def discovered() -> tp.Dict[str, Project]:
     """Return all discovered projects."""
     return ProjectRegistry.projects
 

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -381,6 +381,11 @@ def __split_project_input__(
     return (first, second)
 
 
+def discovered() -> Dict[str, Project]:
+    """Return all discovered projects."""
+    return ProjectRegistry.projects
+
+
 def __add_single_filter__(project: ProjectT, version: str) -> ProjectT:
 
     sources = project.SOURCE
@@ -477,10 +482,7 @@ def populate(projects_to_filter: ProjectNames,
     if projects_to_filter is None:
         projects_to_filter = []
 
-    import benchbuild.projects as all_projects
-    all_projects.discover()
-
-    prjs = ProjectRegistry.projects
+    prjs = discovered()
     if projects_to_filter:
         prjs = {}
 

--- a/benchbuild/reports/__init__.py
+++ b/benchbuild/reports/__init__.py
@@ -14,18 +14,6 @@ from benchbuild.utils import schema
 LOG = logging.getLogger(__name__)
 
 
-def discover():
-    """Import all experiments listed in *_PLUGINS_REPORTS."""
-    if CFG["plugins"]["autoload"]:
-        report_plugins = CFG["plugins"]["reports"].value
-        for plugin in report_plugins:
-            try:
-                importlib.import_module(plugin)
-                LOG.debug("Found report: %s", plugin)
-            except ImportError:
-                LOG.error("Could not find '%s'", plugin)
-
-
 class ReportRegistry(type):
     reports = {}
 
@@ -91,3 +79,8 @@ class Report(metaclass=ReportRegistry):
         else:
             exp_ids = [uuid.UUID(v) for v in self.exp_ids]
         self.experiment_ids = exp_ids
+
+
+def discovered() -> t.Dict[str, Report]:
+    """Return all discovered projects."""
+    return ReportRegistry.reports

--- a/tests/experiments/test_discovery.py
+++ b/tests/experiments/test_discovery.py
@@ -8,16 +8,13 @@ def test_discovery(caplog):
     caplog.set_level(logging.DEBUG, logger='benchbuild')
     CFG['plugins']['projects'] = []
     CFG['plugins']['reports'] = []
-    CFG["plugins"]["experiments"] = [
-        "benchbuild.non.existing", "benchbuild.reports.raw"
-    ]
-
+    CFG["plugins"]["experiments"] = ["benchbuild.non_existing"]
     discover()
     assert caplog.record_tuples == [
         ('benchbuild.plugins', logging.ERROR,
-         "Could not find 'benchbuild.non.existing'"),
-        ('benchbuild.plugins', logging.ERROR,
-         "ImportError: No module named 'benchbuild.non'"),
+         "Could not find 'benchbuild.non_existing'"),
+        ('benchbuild.plugins', logging.DEBUG,
+         "ImportError: No module named 'benchbuild.non_existing'"),
     ]
 
     def_exps = CFG['plugins']['experiments'].node['default']

--- a/tests/experiments/test_discovery.py
+++ b/tests/experiments/test_discovery.py
@@ -1,25 +1,32 @@
 import logging
 
-from benchbuild.experiment import ExperimentRegistry
-from benchbuild.experiments import discover
+from benchbuild.plugins import discover
 from benchbuild.settings import CFG
 
 
 def test_discovery(caplog):
     caplog.set_level(logging.DEBUG, logger='benchbuild')
-    CFG['plugins']['experiments'] = [
+    CFG['plugins']['projects'] = []
+    CFG['plugins']['reports'] = []
+    CFG["plugins"]["experiments"] = [
         "benchbuild.non.existing", "benchbuild.reports.raw"
     ]
 
     discover()
     assert caplog.record_tuples == [
-        ('benchbuild.experiments', logging.ERROR,
+        ('benchbuild.plugins', logging.ERROR,
          "Could not find 'benchbuild.non.existing'"),
-        ('benchbuild.experiments', logging.ERROR,
+        ('benchbuild.plugins', logging.ERROR,
          "ImportError: No module named 'benchbuild.non'"),
     ]
 
-    default = CFG['plugins']['experiments'].node['default']
-    CFG['plugins']['experiments'] = default
+    def_exps = CFG['plugins']['experiments'].node['default']
+    CFG['plugins']['experiments'] = def_exps
+
+    def_prjs = CFG['plugins']['projects'].node['default']
+    CFG['plugins']['projects'] = def_prjs
+
+    def_reports = CFG['plugins']['reports'].node['default']
+    CFG['plugins']['reports'] = def_reports
 
     discover()

--- a/tests/reports/test_discovery.py
+++ b/tests/reports/test_discovery.py
@@ -1,19 +1,21 @@
 import logging
 
-from benchbuild.reports import discover
+from benchbuild.plugins import discover
 from benchbuild.settings import CFG
 
 
 def test_discovery(caplog):
     caplog.set_level(logging.DEBUG, logger='benchbuild')
+    CFG['plugins']['projects'] = []
+    CFG['plugins']['experiments'] = []
     CFG["plugins"]["reports"] = [
         "benchbuild.non.existing", "benchbuild.reports.raw"
     ]
     discover()
 
     assert caplog.record_tuples == [
-        ('benchbuild.reports', logging.ERROR,
+        ('benchbuild.plugins', logging.ERROR,
          "Could not find 'benchbuild.non.existing'"),
-        ('benchbuild.reports', logging.DEBUG,
+        ('benchbuild.plugins', logging.DEBUG,
          "Found report: benchbuild.reports.raw"),
     ]

--- a/tests/reports/test_discovery.py
+++ b/tests/reports/test_discovery.py
@@ -9,13 +9,15 @@ def test_discovery(caplog):
     CFG['plugins']['projects'] = []
     CFG['plugins']['experiments'] = []
     CFG["plugins"]["reports"] = [
-        "benchbuild.non.existing", "benchbuild.reports.raw"
+        'benchbuild.non_existing', 'benchbuild.reports.raw'
     ]
     discover()
 
     assert caplog.record_tuples == [
         ('benchbuild.plugins', logging.ERROR,
-         "Could not find 'benchbuild.non.existing'"),
+         "Could not find 'benchbuild.non_existing'"),
         ('benchbuild.plugins', logging.DEBUG,
+         "ImportError: No module named 'benchbuild.non_existing'"),
+        ('benchbuild.plugins', logging.INFO,
          "Found report: benchbuild.reports.raw"),
     ]


### PR DESCRIPTION
Merge all discoveries into a single unified version. There usually is no reason to avoid initialization of one set of plugins.

Users of benchbuild that trigger experiment/project/report discovery in their code, need to change imports/references to the discover method.

Example:

```
from benchbuild.experiments import discover
```
changes to

```
from benchbuild.plugins import discover
```

Additionally, some accessors to the registries should make the handling of registries less awkward looking. No more ``ExperimentRegistry.experiments[...]``, you can use a proper accessor now ``ExperimentRegistry.discovered()``.
