### PR TITLE
decouple Experiment and Project

### DIFF
--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -50,10 +50,8 @@ class ExperimentRegistry(type):
 
     experiments = {}
 
-    def __new__(
-        mcs: tp.Type[tp.Any], name: str, bases: tp.Tuple[type, ...],
-        attrs: tp.Dict[str, tp.Any]
-    ) -> tp.Any:
+    def __new__(mcs: tp.Type[tp.Any], name: str, bases: tp.Tuple[type, ...],
+                attrs: tp.Dict[str, tp.Any]) -> tp.Any:
         """Register a project in the registry."""
         cls = super(ExperimentRegistry, mcs).__new__(mcs, name, bases, attrs)
         if bases and 'NAME' in attrs:
@@ -98,14 +96,11 @@ class Experiment(metaclass=ExperimentRegistry):
         if not cls.NAME:
             raise AttributeError(
                 "{0} @ {1} does not define a NAME class attribute.".format(
-                    cls.__name__, cls.__module__
-                )
-            )
+                    cls.__name__, cls.__module__))
         return new_self
 
     name: str = attr.ib(
-        default=attr.Factory(lambda self: type(self).NAME, takes_self=True)
-    )
+        default=attr.Factory(lambda self: type(self).NAME, takes_self=True))
 
     projects: Projects = \
         attr.ib(default=attr.Factory(dict))
@@ -126,10 +121,8 @@ class Experiment(metaclass=ExperimentRegistry):
     @id.validator
     def validate_id(self, _: tp.Any, new_id: uuid.UUID) -> None:
         if not isinstance(new_id, uuid.UUID):
-            raise TypeError(
-                "%s expected to be '%s' but got '%s'" %
-                (str(new_id), str(uuid.UUID), str(type(new_id)))
-            )
+            raise TypeError("%s expected to be '%s' but got '%s'" %
+                            (str(new_id), str(uuid.UUID), str(type(new_id))))
 
     schema = attr.ib()
 
@@ -173,12 +166,11 @@ class Experiment(metaclass=ExperimentRegistry):
                 atomic_actions: Actions = [
                     actns.Clean(p),
                     actns.MakeBuildDir(p),
-                    actns.Echo(
-                        message="Selected {0} with version {1}".
-                        format(p.name, version_str)
-                    ),
+                    actns.Echo(message="Selected {0} with version {1}".format(
+                        p.name, version_str)),
                     actns.ProjectEnvironment(p),
                 ]
+                atomic_actions.extend(self.actions_for_project(p))
 
                 prj_actions.append(actns.RequireAll(actions=atomic_actions))
             actions.extend(prj_actions)

--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -33,6 +33,7 @@ from abc import abstractmethod
 import attr
 
 import benchbuild.utils.actions as actns
+from benchbuild.project import build_dir
 from benchbuild.settings import CFG
 from benchbuild.utils.requirements import Requirement
 
@@ -49,8 +50,10 @@ class ExperimentRegistry(type):
 
     experiments = {}
 
-    def __new__(mcs: tp.Type[tp.Any], name: str, bases: tp.Tuple[type, ...],
-                attrs: tp.Dict[str, tp.Any]) -> tp.Any:
+    def __new__(
+        mcs: tp.Type[tp.Any], name: str, bases: tp.Tuple[type, ...],
+        attrs: tp.Dict[str, tp.Any]
+    ) -> tp.Any:
         """Register a project in the registry."""
         cls = super(ExperimentRegistry, mcs).__new__(mcs, name, bases, attrs)
         if bases and 'NAME' in attrs:
@@ -95,11 +98,14 @@ class Experiment(metaclass=ExperimentRegistry):
         if not cls.NAME:
             raise AttributeError(
                 "{0} @ {1} does not define a NAME class attribute.".format(
-                    cls.__name__, cls.__module__))
+                    cls.__name__, cls.__module__
+                )
+            )
         return new_self
 
     name: str = attr.ib(
-        default=attr.Factory(lambda self: type(self).NAME, takes_self=True))
+        default=attr.Factory(lambda self: type(self).NAME, takes_self=True)
+    )
 
     projects: Projects = \
         attr.ib(default=attr.Factory(dict))
@@ -120,8 +126,10 @@ class Experiment(metaclass=ExperimentRegistry):
     @id.validator
     def validate_id(self, _: tp.Any, new_id: uuid.UUID) -> None:
         if not isinstance(new_id, uuid.UUID):
-            raise TypeError("%s expected to be '%s' but got '%s'" %
-                            (str(new_id), str(uuid.UUID), str(type(new_id))))
+            raise TypeError(
+                "%s expected to be '%s' but got '%s'" %
+                (str(new_id), str(uuid.UUID), str(type(new_id)))
+            )
 
     schema = attr.ib()
 
@@ -160,15 +168,16 @@ class Experiment(metaclass=ExperimentRegistry):
                 var_context = source.context(*variant)
                 version_str = source.to_str(*variant)
 
-                p = prj_cls(self, variant=var_context)
+                p = prj_cls(var_context)
+                p.builddir = build_dir(self, p)
                 atomic_actions: Actions = [
                     actns.Clean(p),
                     actns.MakeBuildDir(p),
-                    actns.Echo(message="Selected {0} with version {1}".format(
-                        p.name, version_str)),
+                    actns.Echo(
+                        message="Selected {0} with version {1}".
+                        format(p.name, version_str)
+                    ),
                     actns.ProjectEnvironment(p),
-                    actns.Containerize(obj=p,
-                                       actions=self.actions_for_project(p))
                 ]
 
                 prj_actions.append(actns.RequireAll(actions=atomic_actions))
@@ -199,17 +208,15 @@ class Experiment(metaclass=ExperimentRegistry):
             return [source.context(*variants[0])]
         raise ValueError('At least one variant is rerquired!')
 
-    @staticmethod
-    def default_runtime_actions(project: Project) -> Actions:
+    def default_runtime_actions(self, project: Project) -> Actions:
         """Return a series of actions for a run time experiment."""
         return [
             actns.Compile(project),
-            actns.Run(project),
+            actns.Run(obj=project, project=project, experiment=self),
             actns.Clean(project)
         ]
 
-    @staticmethod
-    def default_compiletime_actions(project: Project) -> Actions:
+    def default_compiletime_actions(self, project: Project) -> Actions:
         """Return a series of actions for a compile time experiment."""
         return [actns.Compile(project), actns.Clean(project)]
 

--- a/benchbuild/experiments/empty.py
+++ b/benchbuild/experiments/empty.py
@@ -6,7 +6,7 @@ directories for benchbuild. No compilation & no run can be done with it.
 """
 
 from benchbuild.experiment import Experiment
-from benchbuild.extensions import run
+from benchbuild.extensions import compiler, run
 from benchbuild.utils.actions import Clean, Compile, MakeBuildDir
 
 
@@ -17,6 +17,8 @@ class Empty(Experiment):
 
     def actions_for_project(self, project):
         """ Do nothing. """
+        project.compiler_extension = run.WithTimeout(
+            compiler.RunCompiler(project, self))
         return [MakeBuildDir(project), Compile(project), Clean(project)]
 
 

--- a/benchbuild/experiments/raw.py
+++ b/benchbuild/experiments/raw.py
@@ -16,7 +16,7 @@ Measurements
     time.real_s - The time spent overall in seconds (aka Wall clock)
 """
 from benchbuild.experiment import Experiment
-from benchbuild.extensions import run, time
+from benchbuild.extensions import compiler, run, time
 
 
 class RawRuntime(Experiment):
@@ -29,4 +29,6 @@ class RawRuntime(Experiment):
         project.cflags = ["-O3", "-fno-omit-frame-pointer"]
         project.runtime_extension = time.RunWithTime(
             run.RuntimeExtension(project, self))
+        project.compiler_extension = run.WithTimeout(
+            compiler.RunCompiler(project, self))
         return self.default_runtime_actions(project)

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -249,7 +249,7 @@ class Project(metaclass=ProjectDecorator):
             run: A function that takes the run command.
         """
 
-    def clean(self):
+    def clean(self) -> None:
         """Clean the project build directory."""
         builddir_p = local.path(self.builddir)
         builddir_p.delete()

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -125,8 +125,6 @@ class Project(metaclass=ProjectDecorator):
         TypeError: Validation of properties may throw a TypeError.
 
     Attributes:
-        experiment (benchbuild.experiment.Experiment):
-            The experiment this project is assigned to.
         name (str, optional):
             The name of this project. Defaults to `NAME`.
         domain (str, optional):
@@ -183,8 +181,6 @@ class Project(metaclass=ProjectDecorator):
                 f'{mod_ident} does not define a GROUP class attribute.')
         return new_self
 
-    experiment = attr.ib()
-
     variant: VariantContext = attr.ib()
 
     @variant.default
@@ -222,7 +218,7 @@ class Project(metaclass=ProjectDecorator):
             raise TypeError("{attribute} must be a valid UUID object")
 
     builddir: local.path = attr.ib(default=attr.Factory(lambda self: local.path(
-        str(CFG["build_dir"])) / self.experiment.name / self.id / self.run_uuid,
+        str(CFG["build_dir"])) / self.id / self.run_uuid,
                                                         takes_self=True))
 
     source: Sources = attr.ib(

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -30,8 +30,6 @@ from plumbum.path.local import LocalPath
 from pygtrie import StringTrie
 
 from benchbuild import source
-from benchbuild.extensions import compiler
-from benchbuild.extensions import run as ext_run
 from benchbuild.settings import CFG
 from benchbuild.utils import db, run, unionfs
 from benchbuild.utils.requirements import Requirement
@@ -236,10 +234,7 @@ class Project(metaclass=ProjectDecorator):
     def __default_primary_source(self) -> str:
         return source.primary(*self.source).key
 
-    compiler_extension = attr.ib(
-        default=attr.Factory(lambda self: ext_run.WithTimeout(
-            compiler.RunCompiler(self, self.experiment)),
-                             takes_self=True))
+    compiler_extension = attr.ib(default=None)
 
     runtime_extension = attr.ib(default=None)
 

--- a/benchbuild/projects/gentoo/portage_gen.py
+++ b/benchbuild/projects/gentoo/portage_gen.py
@@ -92,7 +92,7 @@ def PortageFactory(name, NAME, DOMAIN, BaseClass=autoportage.AutoPortage):
         >>> c = PortageFactory("test", "NAME", "DOMAIN")
         >>> c
         <class '__main__.test'>
-        >>> i = c(Empty())
+        >>> i = c()
         >>> i.NAME
         'NAME'
         >>> i.DOMAIN

--- a/benchbuild/utils/db.py
+++ b/benchbuild/utils/db.py
@@ -1,6 +1,5 @@
 """Database support module for the benchbuild study."""
 import logging
-import os
 
 from sqlalchemy.exc import IntegrityError
 
@@ -46,16 +45,16 @@ def create_run(cmd, project, exp, grp):
     run = s.Run(command=str(cmd),
                 project_name=project.name,
                 project_group=project.group,
-                experiment_name=exp,
+                experiment_name=exp.name,
                 run_group=str(grp),
-                experiment_group=project.experiment.id)
+                experiment_group=exp.id)
     session.add(run)
     session.commit()
 
     return (run, session)
 
 
-def create_run_group(prj):
+def create_run_group(prj, experiment):
     """
     Create a new 'run_group' in the database.
 
@@ -66,6 +65,7 @@ def create_run_group(prj):
 
     Args:
         prj - The project for which we open the run_group.
+        experiment - The experiment this group belongs to.
 
     Returns:
         A tuple (group, session) containing both the newly created run_group and
@@ -74,7 +74,6 @@ def create_run_group(prj):
     from benchbuild.utils import schema as s
 
     session = s.Session()
-    experiment = prj.experiment
     group = s.RunGroup(id=prj.run_uuid, experiment=experiment.id)
     session.add(group)
     session.commit()

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -40,14 +40,14 @@ class RunInfo:
         session ():
     """
 
-    def __begin(self, command, project, ename, group):
+    def __begin(self, command, project, experiment, group):
         """
         Begin a run in the database log.
 
         Args:
             command: The command that will be executed.
-            pname: The project name we belong to.
-            ename: The experiment name we belong to.
+            project: The project we belong to.
+            experiment: The experiment we belong to.
             group: The run group we belong to.
 
         Returns:
@@ -58,7 +58,7 @@ class RunInfo:
         from benchbuild.utils import schema as s
         from datetime import datetime
 
-        db_run, session = create_run(command, project, ename, group)
+        db_run, session = create_run(command, project, experiment, group)
         db_run.begin = datetime.now()
         db_run.status = 'running'
         log = s.RunLog()
@@ -143,7 +143,7 @@ class RunInfo:
     payload = attr.ib(init=False, default=None, repr=False)
 
     def __attrs_post_init__(self):
-        self.__begin(self.cmd, self.project, self.experiment.name,
+        self.__begin(self.cmd, self.project, self.experiment,
                      self.project.run_uuid)
         signals.handlers.register(self.__fail, 15, "SIGTERM", "SIGTERM")
 
@@ -207,7 +207,7 @@ class RunInfo:
         self.session.commit()
 
 
-def begin_run_group(project):
+def begin_run_group(project, experiment):
     """
     Begin a run_group in the database.
 
@@ -224,7 +224,7 @@ def begin_run_group(project):
     from benchbuild.utils.db import create_run_group
     from datetime import datetime
 
-    group, session = create_run_group(project)
+    group, session = create_run_group(project, experiment)
     group.begin = datetime.now()
     group.status = 'running'
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -27,13 +27,6 @@ class EmptyProject(Project):
         pass
 
 
-class EmptyExperiment(Experiment):
-    NAME = "test_empty"
-
-    def actions_for_project(self, project):
-        del project
-
-
 class FailAlways(a.Step):
     NAME = "FAIL ALWAYS"
     DESCRIPTION = "A Step that guarantees to fail."
@@ -53,11 +46,11 @@ class PassAlways(a.Step):
 class ActionsTestCase(unittest.TestCase):
 
     def test_for_all_pass(self):
-        ep = EmptyProject(EmptyExperiment())
+        ep = EmptyProject()
         actn = a.RequireAll(actions=[PassAlways(ep)])
         self.assertEqual(actn(), [a.StepResult.OK])
 
     def test_for_all_fail(self):
-        ep = EmptyProject(EmptyExperiment())
+        ep = EmptyProject()
         actn = a.RequireAll(actions=[FailAlways(ep)])
         self.assertEqual(actn(), [a.StepResult.ERROR])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -33,11 +33,6 @@ class DummyPrjEmptySource(Project):
         raise NotImplementedError()
 
 
-@pytest.fixture
-def dummy_exp():
-    return attr.make_class('TestExp', {'name': attr.ib(default='TestExp')})
-
-
 @pytest.fixture(params=[['1'], ['1', '2']], ids=['single', 'multi'])
 def mksource(request) -> tp.Callable[[str], BaseSource]:
 
@@ -108,8 +103,8 @@ def project(mkproject, request):
 
 
 @pytest.fixture
-def project_instance(project, dummy_exp):
-    return project(experiment=dummy_exp())
+def project_instance(project):
+    return project()
 
 
 def describe_project():
@@ -127,9 +122,9 @@ def describe_project():
         assert local.path(
             project_instance.source_of_primary).name == 'VersionSource_0'
 
-    def source_must_contain_elements(dummy_exp):  # pylint: disable=unused-variable
+    def source_must_contain_elements():  # pylint: disable=unused-variable
         with pytest.raises(TypeError) as excinfo:
-            DummyPrjEmptySource(experiment=dummy_exp())
+            DummyPrjEmptySource()
         assert "primary()" in str(excinfo)
 
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -21,7 +21,7 @@ class TestSLURM(unittest.TestCase):
         test.TestProject.__attrs_post_init__ = unittest.mock.MagicMock()
 
         self.exp = Empty()
-        self.prj = test.TestProject(self.exp)
+        self.prj = test.TestProject()
         self.tmp_file = local.path(tempfile.mktemp())
 
     def tearDown(self):

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -1,7 +1,6 @@
 """
 Test the SLURM script generator.
 """
-import os
 import tempfile
 import unittest
 import unittest.mock

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -56,7 +56,7 @@ class RunCompiler(WrapperTests):
 
     def test_create(self):
         with local.cwd(self.tmp_dir):
-            cmd = compilers.cc(EmptyProject(empty.Empty()))
+            cmd = compilers.cc(EmptyProject())
         self.assertTrue(os.path.exists(str(cmd)))
 
 
@@ -64,7 +64,7 @@ class RunStatic(WrapperTests):
 
     def test_create(self):
         with local.cwd(self.tmp_dir):
-            cmd = wrappers.wrap(self.tmp_script, EmptyProject(empty.Empty()))
+            cmd = wrappers.wrap(self.tmp_script, EmptyProject())
             self.assertTrue(os.path.exists("{}.bin".format(self.tmp_script)))
         self.assertTrue(os.path.exists(str(cmd)))
 
@@ -73,6 +73,5 @@ class RunDynamic(WrapperTests):
 
     def test_create(self):
         with local.cwd(self.tmp_dir):
-            cmd = wrappers.wrap_dynamic(EmptyProject(empty.Empty()),
-                                        self.tmp_script)
+            cmd = wrappers.wrap_dynamic(EmptyProject(), self.tmp_script)
         self.assertTrue(os.path.exists(str(cmd)))

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,7 +6,6 @@ import unittest
 from plumbum import local
 from plumbum.cmd import rm
 
-import benchbuild.experiments.empty as empty
 import benchbuild.project as project
 import benchbuild.utils.compiler as compilers
 import benchbuild.utils.wrapping as wrappers


### PR DESCRIPTION
## Decouple Experiment and Project

This decouples the Experiment and Project classes further.
Steps necessary:
* Remove member attribute 'experiment' from Project
* Do not use an experiment inside the project's default builddir.
* Set an appropriate builddir when the experiment instantiates the project
* Handle database run_groups in the action controller.
* Adjust database persistence functions accordingly.
* Drop run() method from Project. Not needed anymore.
* Drop legacy configuration settings. Not needed anymore(!).
* Set compiler_extension in _every_ experiment is now required.
   A project does not provide one anymore.

## Migration

This series requires you to provide a compiler extension yourself, benchbuild won't
set one up for you. See ``experiments/raw.py`` for an example.
