### PR TITLE
fix: revert benchbuild's wrapping of plumbum

### DIFF
--- a/benchbuild/__init__.py
+++ b/benchbuild/__init__.py
@@ -4,8 +4,6 @@ Public API of benchbuild.
 """
 import sys
 
-import plumbum as pb
-
 # Project utilities
 from benchbuild.project import populate as populate
 
@@ -36,13 +34,7 @@ def __init__() -> None:
 
 __init__()
 
-# Forwards to plumbum
-cwd = pb.local.cwd
-env = pb.local.env
-path = pb.local.path
-
 # Clean the namespace
 del sys
-del pb
 del __PLUGINS__
 del __SETTINGS__

--- a/benchbuild/projects/apollo/rodinia.py
+++ b/benchbuild/projects/apollo/rodinia.py
@@ -1,4 +1,5 @@
 import attr
+from plumbum import local
 
 import benchbuild as bb
 from benchbuild.source import HTTP
@@ -26,7 +27,7 @@ class RodiniaGroup(bb.Project):
     def compile(self):
         tar('xf', 'rodinia.tar.bz2')
         rodinia_version = self.version_of('rodinia.tar.bz2')
-        unpack_dir = bb.path(f'rodinia_{rodinia_version}')
+        unpack_dir = local.path(f'rodinia_{rodinia_version}')
 
         c_compiler = bb.compiler.cc(self)
         cxx_compiler = bb.compiler.cxx(self)
@@ -35,7 +36,7 @@ class RodiniaGroup(bb.Project):
         config_src = self.config['src']
         config_flags = self.config['flags']
 
-        with bb.cwd(unpack_dir / config_dir):
+        with local.cwd(unpack_dir / config_dir):
             for outfile, srcfiles in config_src.items():
                 cls = type(self)
                 _cc = cls.select_compiler(c_compiler, cxx_compiler)
@@ -52,13 +53,13 @@ class RodiniaGroup(bb.Project):
 
     def run_tests(self):
         rodinia_version = self.version_of('rodinia.tar.bz2')
-        unpack_dir = bb.path(f'rodinia_{rodinia_version}')
+        unpack_dir = local.path(f'rodinia_{rodinia_version}')
         in_src_dir = unpack_dir / self.config['dir']
 
         for outfile in self.config['src']:
             bb.wrap(in_src_dir / outfile, self)
 
-        with bb.cwd(in_src_dir):
+        with local.cwd(in_src_dir):
             sh_ = bb.watch(sh)
             sh_('./run')
 

--- a/benchbuild/projects/apollo/scimark.py
+++ b/benchbuild/projects/apollo/scimark.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import HTTP
 from benchbuild.utils.cmd import make, unzip
@@ -16,13 +18,13 @@ class SciMark(bb.Project):
     ]
 
     def compile(self):
-        scimark_source = bb.path(self.source_of('scimark.zip'))
+        scimark_source = local.path(self.source_of('scimark.zip'))
         clang = bb.compiler.cc(self)
         _clang = bb.watch(clang)
-        unzip(bb.cwd / scimark_source)
+        unzip(local.cwd / scimark_source)
         make("CC=" + str(_clang), "scimark2")
 
     def run_tests(self):
-        scimark2 = bb.wrap(bb.path('scimark2'), self)
+        scimark2 = bb.wrap(local.path('scimark2'), self)
         _scimark2 = bb.watch(scimark2)
         _scimark2()

--- a/benchbuild/projects/benchbuild/bots.py
+++ b/benchbuild/projects/benchbuild/bots.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import Git
 from benchbuild.utils.cmd import make, mkdir
@@ -62,7 +64,7 @@ class BOTSGroup(bb.Project):
     }
 
     def compile(self):
-        bots_repo = bb.path(self.source_of('bots.git'))
+        bots_repo = local.path(self.source_of('bots.git'))
         makefile_config = bots_repo / "config" / "make.config"
         clang = bb.compiler.cc(self)
 
@@ -89,13 +91,13 @@ class BOTSGroup(bb.Project):
             lines = [l.format(cc=clang) + "\n" for l in lines]
             config.writelines(lines)
         mkdir(bots_repo / "bin")
-        with bb.cwd(bots_repo):
+        with local.cwd(bots_repo):
             _make = bb.watch(make)
             _make("-C", self.path_dict[self.name])
 
     def run_tests(self):
         binary_name = "{name}.benchbuild.serial".format(name=self.name)
-        bots_repo = bb.path(self.source_of('bots.git'))
+        bots_repo = local.path(self.source_of('bots.git'))
         binary_path = bots_repo / "bin" / binary_name
         exp = bb.wrap(binary_path, self)
         _exp = bb.watch(exp)

--- a/benchbuild/projects/benchbuild/bzip2.py
+++ b/benchbuild/projects/benchbuild/bzip2.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import HTTP, Git
 from benchbuild.utils.cmd import make, tar
@@ -19,17 +21,17 @@ class Bzip2(bb.Project):
     ]
 
     def compile(self):
-        bzip2_repo = bb.path(self.source_of('bzip2.git'))
-        compression_source = bb.path(self.source_of('compression.tar.gz'))
+        bzip2_repo = local.path(self.source_of('bzip2.git'))
+        compression_source = local.path(self.source_of('compression.tar.gz'))
         tar('xf', compression_source)
 
         clang = bb.compiler.cc(self)
-        with bb.cwd(bzip2_repo):
+        with local.cwd(bzip2_repo):
             make_ = bb.watch(make)
             make_("CFLAGS=-O3", "CC=" + str(clang), "clean", "bzip2")
 
     def run_tests(self):
-        bzip2_repo = bb.path(self.source_of('bzip2.git'))
+        bzip2_repo = local.path(self.source_of('bzip2.git'))
         bzip2 = bb.wrap(bzip2_repo / "bzip2", self)
         _bzip2 = bb.watch(bzip2)
 

--- a/benchbuild/projects/benchbuild/ccrypt.py
+++ b/benchbuild/projects/benchbuild/ccrypt.py
@@ -19,7 +19,7 @@ class Ccrypt(bb.Project):
     ]
 
     def compile(self):
-        ccrypt_source = bb.path(self.source_of('ccrypt.tar.gz'))
+        ccrypt_source = local.path(self.source_of('ccrypt.tar.gz'))
         ccrypt_version = self.version_of('ccrypt.tar.gz')
         tar('xfz', ccrypt_source)
         unpack_dir = f'ccrypt-{ccrypt_version}'
@@ -27,10 +27,10 @@ class Ccrypt(bb.Project):
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             configure = local["./configure"]
             _configure = bb.watch(configure)
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 _configure()
             _make = bb.watch(make)
             _make("check")
@@ -38,10 +38,10 @@ class Ccrypt(bb.Project):
     def run_tests(self):
         ccrypt_version = self.version_of('ccrypt.tar.gz')
         unpack_dir = f'ccrypt-{ccrypt_version}'
-        with bb.cwd(unpack_dir):
-            bb.wrap(bb.path("src") / self.name, self)
-            bb.wrap(bb.path("check") / "crypt3-check", self)
-            bb.wrap(bb.path("check") / "rijndael-check", self)
+        with local.cwd(unpack_dir):
+            bb.wrap(local.path("src") / self.name, self)
+            bb.wrap(local.path("check") / "crypt3-check", self)
+            bb.wrap(local.path("check") / "rijndael-check", self)
 
             _make = bb.watch(make)
             _make("check")

--- a/benchbuild/projects/benchbuild/crafty.py
+++ b/benchbuild/projects/benchbuild/crafty.py
@@ -35,7 +35,6 @@ class Crafty(bb.Project):
         unpack_dir = "crafty.src"
         mkdir(unpack_dir)
 
-        from plumbum import local
         with local.cwd(unpack_dir):
             unzip(crafty_source)
         mv(book_source, unpack_dir)

--- a/benchbuild/projects/benchbuild/crocopat.py
+++ b/benchbuild/projects/benchbuild/crocopat.py
@@ -37,16 +37,16 @@ class Crocopat(bb.Project):
                 _crocopat_project(retcode=None)
 
     def compile(self):
-        crocopat_source = bb.path(self.source_of('crocopat.zip'))
+        crocopat_source = local.path(self.source_of('crocopat.zip'))
         crocopat_version = self.version_of('crocopat.zip')
         unzip(crocopat_source)
         unpack_dir = f'crocopat-{crocopat_version}'
 
-        crocopat_dir = bb.path(unpack_dir) / "src"
+        crocopat_dir = local.path(unpack_dir) / "src"
         self.cflags += ["-I.", "-ansi"]
         self.ldflags += ["-L.", "-lrelbdd"]
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(crocopat_dir):
+        with local.cwd(crocopat_dir):
             _make = bb.watch(make)
             _make("CXX=" + str(clang_cxx))

--- a/benchbuild/projects/benchbuild/ffmpeg.py
+++ b/benchbuild/projects/benchbuild/ffmpeg.py
@@ -23,21 +23,21 @@ class LibAV(bb.Project):
 
     def run_tests(self):
         ffmpeg_version = self.version_of('ffmpeg.tar.bz2')
-        unpack_dir = bb.path(f'ffmpeg-{ffmpeg_version}')
+        unpack_dir = local.path(f'ffmpeg-{ffmpeg_version}')
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             bb.wrap(self.name, self)
             _make = bb.watch(make)
             _make("V=1", "-i", "fate")
 
     def compile(self):
-        ffmpeg_source = bb.path(self.source_of('ffmpeg.tar.bz2'))
+        ffmpeg_source = local.path(self.source_of('ffmpeg.tar.bz2'))
         ffmpeg_version = self.version_of('ffmpeg.tar.bz2')
         tar('xfj', ffmpeg_source)
-        unpack_dir = bb.path(f'ffmpeg-{ffmpeg_version}')
+        unpack_dir = local.path(f'ffmpeg-{ffmpeg_version}')
         clang = bb.compiler.cc(self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             bb.download.Rsync(self.fate_uri, self.fate_dir)
             configure = local["./configure"]
             _configure = bb.watch(configure)

--- a/benchbuild/projects/benchbuild/gzip.py
+++ b/benchbuild/projects/benchbuild/gzip.py
@@ -22,7 +22,7 @@ class Gzip(bb.Project):
 
     def run_tests(self):
         gzip_version = self.version_of('gzip.tar.xz')
-        unpack_dir = bb.path(f'gzip-{gzip_version}.tar.xz')
+        unpack_dir = local.path(f'gzip-{gzip_version}.tar.xz')
 
         gzip = bb.wrap(unpack_dir / "gzip", self)
         _gzip = bb.watch(gzip)
@@ -42,8 +42,8 @@ class Gzip(bb.Project):
         _gzip("-f", "-k", "--decompress", "compression/liberty.jpg.gz")
 
     def compile(self):
-        gzip_source = bb.path(self.source_of('gzip.tar.xz'))
-        compression_source = bb.path(self.source_of('compression.tar.gz'))
+        gzip_source = local.path(self.source_of('gzip.tar.xz'))
+        compression_source = local.path(self.source_of('compression.tar.gz'))
 
         tar('xfJ', gzip_source)
         tar('xf', compression_source)
@@ -52,9 +52,9 @@ class Gzip(bb.Project):
         unpack_dir = "gzip-{0}.tar.xz".format(gzip_version)
 
         clang = bb.compiler.cc(self)
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             _configure = bb.watch(local["./configure"])
-            with bb.env(CC=str(clang)):
+            with local.env(CC=str(clang)):
                 _configure("--disable-dependency-tracking",
                            "--disable-silent-rules", "--with-gnu-ld")
             _make = bb.watch(make)

--- a/benchbuild/projects/benchbuild/js.py
+++ b/benchbuild/projects/benchbuild/js.py
@@ -25,42 +25,42 @@ class SpiderMonkey(bb.Project):
     ]
 
     def compile(self):
-        gecko_repo = bb.path(self.source_of('gecko-dev.git'))
+        gecko_repo = local.path(self.source_of('gecko-dev.git'))
 
         js_dir = gecko_repo / "js" / "src"
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
-        with bb.cwd(js_dir):
+        with local.cwd(js_dir):
             make_src_pkg = local["./make-source-package.sh"]
-            with bb.env(DIST=self.builddir,
-                        MOZJS_MAJOR_VERSION=0,
-                        MOZJS_MINOR_VERSION=0,
-                        MOZJS_PATCH_VERSION=0):
+            with local.env(DIST=self.builddir,
+                           MOZJS_MAJOR_VERSION=0,
+                           MOZJS_MINOR_VERSION=0,
+                           MOZJS_PATCH_VERSION=0):
                 make_src_pkg()
 
-        mozjs_dir = bb.path("mozjs-0.0.0")
+        mozjs_dir = local.path("mozjs-0.0.0")
         mozjs_src_dir = mozjs_dir / "js" / "src"
         tar("xfj", mozjs_dir + ".tar.bz2")
-        with bb.cwd(mozjs_src_dir):
+        with local.cwd(mozjs_src_dir):
             mkdir("obj")
             autoconf = local["autoconf-2.13"]
             autoconf()
-            with bb.cwd("obj"):
-                with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.cwd("obj"):
+                with local.env(CC=str(clang), CXX=str(clang_cxx)):
                     configure = local["../configure"]
                     _configure = bb.watch(configure)
                     _configure('--without-system-zlib')
 
         mozjs_obj_dir = mozjs_src_dir / "obj"
-        with bb.cwd(mozjs_obj_dir):
+        with local.cwd(mozjs_obj_dir):
             _make = bb.watch(make)
             _make("-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
-        mozjs_obj_dir = bb.path("mozjs-0.0.0") / "js" / "src" / "obj"
+        mozjs_obj_dir = local.path("mozjs-0.0.0") / "js" / "src" / "obj"
         self.runtime_extension = partial(self, may_wrap=False)
         bb.wrap(mozjs_obj_dir / "js" / "src" / "shell" / "js", self)
 
-        with bb.cwd(mozjs_obj_dir):
+        with local.cwd(mozjs_obj_dir):
             _make = bb.watch(make)
             _make("check-jstests")

--- a/benchbuild/projects/benchbuild/lammps.py
+++ b/benchbuild/projects/benchbuild/lammps.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import Git
 from benchbuild.utils.cmd import make
@@ -17,7 +19,7 @@ class Lammps(bb.Project):
     ]
 
     def run_tests(self):
-        lammps_repo = bb.path(self.source_of('lammps.git'))
+        lammps_repo = local.path(self.source_of('lammps.git'))
         src = lammps_repo / 'src'
         examples = lammps_repo / "examples"
 
@@ -26,17 +28,17 @@ class Lammps(bb.Project):
 
         for test in tests:
             dirname = test.dirname
-            with bb.cwd(dirname):
+            with local.cwd(dirname):
                 _lmp_serial = bb.watch((lmp_serial < test))
                 _lmp_serial(retcode=None)
 
     def compile(self):
-        lammps_repo = bb.path(self.source_of('lammps.git'))
+        lammps_repo = local.path(self.source_of('lammps.git'))
         src = lammps_repo / 'src'
 
         self.ldflags += ["-lgomp"]
         clang_cxx = bb.compiler.cxx(self)
-        with bb.cwd(src):
+        with local.cwd(src):
             _make = bb.watch(make)
             _make("CC=" + str(clang_cxx), "LINK=" + str(clang_cxx), "clean",
                   "serial")

--- a/benchbuild/projects/benchbuild/lapack.py
+++ b/benchbuild/projects/benchbuild/lapack.py
@@ -21,9 +21,9 @@ class OpenBlas(bb.Project):
     ]
 
     def compile(self):
-        openblas_repo = bb.path(self.source_of('OpenBLAS'))
+        openblas_repo = local.path(self.source_of('OpenBLAS'))
         clang = bb.compiler.cc(self)
-        with bb.cwd(openblas_repo):
+        with local.cwd(openblas_repo):
             _make = bb.watch(make)
             _make("CC=" + str(clang))
 
@@ -42,7 +42,7 @@ class Lapack(bb.Project):
     ]
 
     def compile(self):
-        clapack_source = bb.path(self.source_of('clapack.tgz'))
+        clapack_source = local.path(self.source_of('clapack.tgz'))
         clapack_version = self.version_of('clapack.tgz')
 
         tar("xfz", clapack_source)
@@ -50,7 +50,7 @@ class Lapack(bb.Project):
 
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             with open("make.inc", 'w') as makefile:
                 content = [
                     "SHELL     = /bin/sh\n", "PLAT      = _LINUX\n",
@@ -73,14 +73,14 @@ class Lapack(bb.Project):
 
             _make = bb.watch(make)
             _make("-j", get_number_of_jobs(CFG), "f2clib", "blaslib")
-            with bb.cwd(local.path("BLAS") / "TESTING"):
+            with local.cwd(local.path("BLAS") / "TESTING"):
                 _make("-j", get_number_of_jobs(CFG), "-f", "Makeblat2")
                 _make("-j", get_number_of_jobs(CFG), "-f", "Makeblat3")
 
     def run_tests(self):
         clapack_version = self.version_of('clapack.tgz')
-        unpack_dir = bb.path("CLAPACK-{0}".format(clapack_version))
-        with bb.cwd(unpack_dir / "BLAS"):
+        unpack_dir = local.path("CLAPACK-{0}".format(clapack_version))
+        with local.cwd(unpack_dir / "BLAS"):
             xblat2s = bb.wrap("xblat2s", self)
             _xblat2s = bb.watch((xblat2s < "sblat2.in"))
             _xblat2s()

--- a/benchbuild/projects/benchbuild/leveldb.py
+++ b/benchbuild/projects/benchbuild/leveldb.py
@@ -1,5 +1,7 @@
 from os import getenv
 
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import Git
 from benchbuild.utils.cmd import make
@@ -17,13 +19,13 @@ class LevelDB(bb.Project):
     ]
 
     def compile(self):
-        leveldb_repo = bb.path(self.source_of('leveldb.src'))
+        leveldb_repo = local.path(self.source_of('leveldb.src'))
 
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(leveldb_repo):
-            with bb.env(CXX=str(clang_cxx), CC=str(clang)):
+        with local.cwd(leveldb_repo):
+            with local.env(CXX=str(clang_cxx), CC=str(clang)):
                 _make = bb.watch(make)
                 _make("clean")
                 _make("all", "-i")
@@ -35,10 +37,10 @@ class LevelDB(bb.Project):
         Args:
             experiment: The experiment's run function.
         """
-        leveldb_repo = bb.path(self.source_of('leveldb.src'))
+        leveldb_repo = local.path(self.source_of('leveldb.src'))
 
         leveldb = bb.wrap(leveldb_repo / "out-static" / "db_bench", self)
         _leveldb = bb.watch(leveldb)
-        with bb.env(LD_LIBRARY_PATH="{}:{}".format(
+        with local.env(LD_LIBRARY_PATH="{}:{}".format(
                 leveldb_repo / "out-shared", getenv("LD_LIBRARY_PATH", ""))):
             _leveldb()

--- a/benchbuild/projects/benchbuild/lulesh.py
+++ b/benchbuild/projects/benchbuild/lulesh.py
@@ -18,17 +18,17 @@ class Lulesh(bb.Project):
     ]
 
     def compile(self):
-        lulesh_repo = bb.path(self.source_of('lulesh.git'))
+        lulesh_repo = local.path(self.source_of('lulesh.git'))
         self.cflags += ["-DUSE_MPI=0"]
 
         cxx_files = local.cwd / lulesh_repo // "*.cc"
         clang = bb.compiler.cxx(self)
-        with bb.cwd(lulesh_repo):
+        with local.cwd(lulesh_repo):
             for src_file in cxx_files:
                 clang("-c", "-o", src_file + '.o', src_file)
 
         obj_files = local.cwd / lulesh_repo // "*.cc.o"
-        with bb.cwd(lulesh_repo):
+        with local.cwd(lulesh_repo):
             clang(obj_files, "-lm", "-o", "../lulesh")
 
     def run_tests(self):
@@ -53,17 +53,17 @@ class LuleshOMP(bb.Project):
     ]
 
     def compile(self):
-        lulesh_repo = bb.path(self.source_of('lulesh.git'))
+        lulesh_repo = local.path(self.source_of('lulesh.git'))
         self.cflags = ['-DUSE_MPI=0', '-fopenmp']
 
-        cxx_files = bb.cwd / lulesh_repo // "*.cc"
+        cxx_files = local.cwd / lulesh_repo // "*.cc"
         clang = bb.compiler.cxx(self)
-        with bb.cwd(lulesh_repo):
+        with local.cwd(lulesh_repo):
             for src_file in cxx_files:
                 clang("-c", "-o", src_file + '.o', src_file)
 
-        obj_files = bb.cwd / lulesh_repo // "*.cc.o"
-        with bb.cwd(lulesh_repo):
+        obj_files = local.cwd / lulesh_repo // "*.cc.o"
+        with local.cwd(lulesh_repo):
             clang(obj_files, "-lm", "-o", "../lulesh")
 
     def run_tests(self):

--- a/benchbuild/projects/benchbuild/minisat.py
+++ b/benchbuild/projects/benchbuild/minisat.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import HTTP, Git
 from benchbuild.utils.cmd import git, make, tar
@@ -22,13 +24,13 @@ class Minisat(bb.Project):
     ]
 
     def run_tests(self):
-        minisat_repo = bb.path(self.source_of('minisat.git'))
+        minisat_repo = local.path(self.source_of('minisat.git'))
         minisat_build = minisat_repo / 'build' / 'dynamic'
         minisat_lib = minisat_build / 'lib'
         minisat_bin = minisat_build / 'bin'
 
-        test_source = bb.path(self.source_of('inputs.tar.gz'))
-        test_dir = bb.path('./minisat/')
+        test_source = local.path(self.source_of('inputs.tar.gz'))
+        test_dir = local.path('./minisat/')
         tar('xf', test_source)
 
         testfiles = test_dir // "*.cnf.gz"
@@ -40,8 +42,8 @@ class Minisat(bb.Project):
             _minisat()
 
     def compile(self):
-        minisat_repo = bb.path(self.source_of('minisat.git'))
-        with bb.cwd(minisat_repo):
+        minisat_repo = local.path(self.source_of('minisat.git'))
+        with local.cwd(minisat_repo):
             # FIXME: That needs to be modeled with Git() download handlers.
             git("fetch", "origin", "pull/17/head:clang")
             git("checkout", "clang")

--- a/benchbuild/projects/benchbuild/openssl.py
+++ b/benchbuild/projects/benchbuild/openssl.py
@@ -31,7 +31,7 @@ class LibreSSL(bb.Project):
     ]
 
     def compile(self):
-        libressl_source = bb.path(self.source_of('libressl.tar.gz'))
+        libressl_source = local.path(self.source_of('libressl.tar.gz'))
         libressl_version = self.version_of('libressl.tar.gz')
 
         self.cflags += ["-fPIC"]
@@ -39,13 +39,13 @@ class LibreSSL(bb.Project):
         clang = bb.compiler.cc(self)
 
         tar("xfz", libressl_source)
-        unpack_dir = bb.path(f'libressl-{libressl_version}')
+        unpack_dir = local.path(f'libressl-{libressl_version}')
         configure = local[unpack_dir / "configure"]
         _configure = bb.watch(configure)
         _make = bb.watch(make)
 
-        with bb.cwd(unpack_dir):
-            with bb.env(CC=str(clang)):
+        with local.cwd(unpack_dir):
+            with local.env(CC=str(clang)):
                 _configure("--disable-asm", "--disable-shared",
                            "--enable-static", "--disable-dependency-tracking",
                            "--with-pic=yes")
@@ -57,11 +57,11 @@ class LibreSSL(bb.Project):
 
     def run_tests(self):
         libressl_version = self.version_of('libressl.tar.gz')
-        unpack_dir = bb.path(f'libressl-{libressl_version}')
-        with bb.cwd(unpack_dir / "tests"):
+        unpack_dir = local.path(f'libressl-{libressl_version}')
+        with local.cwd(unpack_dir / "tests"):
             for binary in LibreSSL.BINARIES:
-                bb.wrap(bb.cwd / binary, self)
+                bb.wrap(local.cwd / binary, self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             _make = bb.watch(make)
             _make("V=1", "check", "-i")

--- a/benchbuild/projects/benchbuild/python.py
+++ b/benchbuild/projects/benchbuild/python.py
@@ -20,19 +20,19 @@ class Python(bb.Project):
     ]
 
     def compile(self):
-        python_source = bb.path(self.source_of('python.tar.xz'))
+        python_source = local.path(self.source_of('python.tar.xz'))
         python_version = self.version_of('python.tar.xz')
 
         tar("xfJ", python_source)
-        unpack_dir = bb.path(f'Python-{python_version}')
+        unpack_dir = local.path(f'Python-{python_version}')
 
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             configure = local["./configure"]
             configure = bb.watch(configure)
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 configure("--disable-shared", "--without-gcc")
 
             _make = bb.watch(make)
@@ -40,9 +40,9 @@ class Python(bb.Project):
 
     def run_tests(self):
         python_version = self.version_of('python.tar.xz')
-        unpack_dir = bb.path(f'Python-{python_version}')
+        unpack_dir = local.path(f'Python-{python_version}')
         bb.wrap(unpack_dir / "python", self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             _make = bb.watch(make)
             _make("-i", "test")

--- a/benchbuild/projects/benchbuild/rasdaman.py
+++ b/benchbuild/projects/benchbuild/rasdaman.py
@@ -28,28 +28,28 @@ class Rasdaman(bb.Project):
     gdal_uri = "https://github.com/OSGeo/gdal"
 
     def compile(self):
-        rasdaman_repo = bb.path(self.source_of('rasdaman.git'))
-        gdal_repo = bb.path(self.source_of('gdal.git'))
+        rasdaman_repo = local.path(self.source_of('rasdaman.git'))
+        gdal_repo = local.path(self.source_of('gdal.git'))
 
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(gdal_repo):
+        with local.cwd(gdal_repo):
             configure = local["./configure"]
             _configure = bb.watch(configure)
 
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 _configure("--with-pic", "--enable-static", "--with-gnu-ld",
                            "--without-ld-shared", "--without-libtool")
                 _make = bb.watch(make)
                 _make("-j", get_number_of_jobs(CFG))
 
-        with bb.cwd(rasdaman_repo):
+        with local.cwd(rasdaman_repo):
             autoreconf("-i")
             configure = local["./configure"]
             _configure = bb.watch(configure)
 
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 _configure("--without-debug-symbols", "--with-static-libs",
                            "--disable-java", "--with-pic", "--disable-debug",
                            "--without-docs")

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -51,5 +51,5 @@ class Ruby(bb.Project):
             ruby(
                 test_dir / "benchmark" / "run.rb",
                 "--ruby=\"" + str(ruby_n) + "\"",
-                "--opts=\"-I" + testdir / "lib" + " -I" + testdir / "." +
-                " -I" + testdir / ".ext" / "common" + "\"", "-r")
+                "--opts=\"-I" + test_dir / "lib" + " -I" + test_dir / "." +
+                " -I" + test_dir / ".ext" / "common" + "\"", "-r")

--- a/benchbuild/projects/benchbuild/ruby.py
+++ b/benchbuild/projects/benchbuild/ruby.py
@@ -25,15 +25,15 @@ class Ruby(bb.Project):
     ]
 
     def compile(self):
-        ruby_source = bb.path(self.source_of('ruby.tar.gz'))
+        ruby_source = local.path(self.source_of('ruby.tar.gz'))
         ruby_version = self.version_of('ruby.tar.gz')
         tar("xfz", ruby_source)
-        unpack_dir = bb.path(f'ruby-{ruby_version}')
+        unpack_dir = local.path(f'ruby-{ruby_version}')
 
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
-        with bb.cwd(unpack_dir):
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+        with local.cwd(unpack_dir):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 configure = local["./configure"]
                 configure = bb.watch(configure)
                 configure("--with-static-linked-ext", "--disable-shared")
@@ -42,14 +42,14 @@ class Ruby(bb.Project):
 
     def run_tests(self):
         ruby_version = self.version_of('ruby.tar.gz')
-        unpack_dir = bb.path(f'ruby-{ruby_version}')
+        unpack_dir = local.path(f'ruby-{ruby_version}')
         ruby_n = bb.wrap(unpack_dir / "ruby", self)
-        test_dir = bb.path('./ruby/')
+        test_dir = local.path('./ruby/')
 
-        with bb.env(RUBYOPT=""):
+        with local.env(RUBYOPT=""):
             _ = bb.watch(ruby)
             ruby(
                 test_dir / "benchmark" / "run.rb",
                 "--ruby=\"" + str(ruby_n) + "\"",
-                "--opts=\"-I" + test_dir / "lib" + " -I" + test_dir / "." +
-                " -I" + test_dir / ".ext" / "common" + "\"", "-r")
+                "--opts=\"-I" + testdir / "lib" + " -I" + testdir / "." +
+                " -I" + testdir / ".ext" / "common" + "\"", "-r")

--- a/benchbuild/projects/benchbuild/sdcc.py
+++ b/benchbuild/projects/benchbuild/sdcc.py
@@ -20,10 +20,10 @@ class SDCC(bb.Project):
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(self.SRC_FILE):
+        with local.cwd(self.SRC_FILE):
             configure = local["./configure"]
             _configure = bb.watch(configure)
-            with bb.env(CC=str(clang), CXX=str(clang_cxx)):
+            with local.env(CC=str(clang), CXX=str(clang_cxx)):
                 _configure("--without-ccache", "--disable-pic14-port",
                            "--disable-pic16-port")
 

--- a/benchbuild/projects/benchbuild/sevenz.py
+++ b/benchbuild/projects/benchbuild/sevenz.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.source import HTTP
 from benchbuild.utils.cmd import cp, make, tar
@@ -18,9 +20,9 @@ class SevenZip(bb.Project):
     ]
 
     def compile(self):
-        sevenzip_source = bb.path(self.source_of('p7zip.tar.bz2'))
+        sevenzip_source = local.path(self.source_of('p7zip.tar.bz2'))
         sevenzip_version = self.version_of('p7zip.tar.bz2')
-        unpack_dir = bb.path(f'p7zip_{sevenzip_version}')
+        unpack_dir = local.path(f'p7zip_{sevenzip_version}')
         tar('xfj', sevenzip_source)
 
         cp(unpack_dir / "makefile.linux_clang_amd64_asm",
@@ -29,13 +31,13 @@ class SevenZip(bb.Project):
         clang = bb.compiler.cc(self)
         clang_cxx = bb.compiler.cxx(self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             _make = bb.watch(make)
             _make("CC=" + str(clang), "CXX=" + str(clang_cxx), "clean", "all")
 
     def run_tests(self):
         sevenzip_version = self.version_of('p7zip.tar.bz2')
-        unpack_dir = bb.path(f'p7zip_{sevenzip_version}')
+        unpack_dir = local.path(f'p7zip_{sevenzip_version}')
         _7z = bb.wrap(unpack_dir / "bin" / "7za", self)
         _7z = bb.watch(_7z)
         _7z("b", "-mmt1")

--- a/benchbuild/projects/benchbuild/tcc.py
+++ b/benchbuild/projects/benchbuild/tcc.py
@@ -22,17 +22,17 @@ class TCC(bb.Project):
     ]
 
     def compile(self):
-        tcc_source = bb.path(self.source_of('tcc.tar.bz2'))
+        tcc_source = local.path(self.source_of('tcc.tar.bz2'))
         tcc_version = self.version_of('tcc.tar.bz2')
 
         tar("xf", tcc_source)
-        unpack_dir = bb.path(f'tcc-{tcc_version}.tar.bz2')
+        unpack_dir = local.path(f'tcc-{tcc_version}.tar.bz2')
 
         clang = bb.compiler.cc(self)
 
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             mkdir("build")
-            with bb.cwd("build"):
+            with local.cwd("build"):
                 configure = local["../configure"]
                 _configure = bb.watch(configure)
                 _configure("--cc=" + str(clang), "--with-libgcc")
@@ -42,9 +42,9 @@ class TCC(bb.Project):
 
     def run_tests(self):
         tcc_version = self.version_of('tcc.tar.bz2')
-        unpack_dir = bb.path(f'tcc-{tcc_version}.tar.bz2')
-        with bb.cwd(unpack_dir):
-            with bb.cwd("build"):
+        unpack_dir = local.path(f'tcc-{tcc_version}.tar.bz2')
+        with local.cwd(unpack_dir):
+            with local.cwd("build"):
                 bb.wrap("tcc", self)
                 inc_path = path.abspath("..")
                 _make = bb.watch(make)

--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -27,14 +27,14 @@ class X264(bb.Project):
     CONFIG = {"tbbt-small": [], "sintel": ["--input-res", "1280x720"]}
 
     def compile(self):
-        x264_repo = bb.path(self.source_of('x264.git'))
+        x264_repo = local.path(self.source_of('x264.git'))
         clang = bb.compiler.cc(self)
 
-        with bb.cwd(x264_repo):
+        with local.cwd(x264_repo):
             configure = local["./configure"]
             _configure = bb.watch(configure)
 
-            with bb.env(CC=str(clang)):
+            with local.env(CC=str(clang)):
                 _configure("--disable-thread", "--disable-opencl",
                            "--enable-pic")
 
@@ -42,7 +42,7 @@ class X264(bb.Project):
             _make("clean", "all", "-j", get_number_of_jobs(CFG))
 
     def run_tests(self):
-        x264_repo = bb.path(self.source_of('x264.git'))
+        x264_repo = local.path(self.source_of('x264.git'))
         inputfiles = [self.source_of('tbbt-small'), self.source_of('sintel')]
 
         x264 = bb.wrap(x264_repo / "x264", self)

--- a/benchbuild/projects/benchbuild/xz.py
+++ b/benchbuild/projects/benchbuild/xz.py
@@ -20,19 +20,19 @@ class XZ(bb.Project):
     ]
 
     def compile(self):
-        xz_source = bb.path(self.source_of('xz.tar.gz'))
+        xz_source = local.path(self.source_of('xz.tar.gz'))
         xz_version = self.version_of('xz.tar.gz')
-        compression_source = bb.path(self.source_of('compression.tar.gz'))
+        compression_source = local.path(self.source_of('compression.tar.gz'))
 
         tar('xf', xz_source)
         tar('xf', compression_source)
 
-        unpack_dir = bb.path(f'xz-{xz_version}')
+        unpack_dir = local.path(f'xz-{xz_version}')
         clang = bb.compiler.cc(self)
-        with bb.cwd(unpack_dir):
+        with local.cwd(unpack_dir):
             configure = local["./configure"]
             _configure = bb.watch(configure)
-            with bb.env(CC=str(clang)):
+            with local.env(CC=str(clang)):
                 _configure("--enable-threads=no", "--with-gnu-ld=yes",
                            "--disable-shared", "--disable-dependency-tracking",
                            "--disable-xzdec", "--disable-lzmadec",
@@ -44,7 +44,7 @@ class XZ(bb.Project):
 
     def run_tests(self):
         xz_version = self.version_of('xz.tar.gz')
-        unpack_dir = bb.path(f'xz-{xz_version}')
+        unpack_dir = local.path(f'xz-{xz_version}')
         xz = bb.wrap(unpack_dir / "src" / "xz" / "xz", self)
         _xz = bb.watch(xz)
 

--- a/benchbuild/projects/gentoo/autoportage.py
+++ b/benchbuild/projects/gentoo/autoportage.py
@@ -15,7 +15,7 @@ class AutoPortage(GentooGroup):
     def compile(self):
         emerge_in_chroot = uchroot.uchroot()["/usr/bin/emerge"]
         prog = self.DOMAIN + "/" + str(self.NAME)[len(self.DOMAIN) + 1:]
-        with bb.env(CONFIG_PROTECT="-*"):
+        with local.env(CONFIG_PROTECT="-*"):
             emerge_in_chroot("--autounmask-only=y",
                              "--autounmask-write=y",
                              prog,

--- a/benchbuild/projects/gentoo/bzip2.py
+++ b/benchbuild/projects/gentoo/bzip2.py
@@ -1,6 +1,8 @@
 """
 bzip2 experiment within gentoo chroot.
 """
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.cmd import tar
@@ -28,7 +30,7 @@ class BZip2(GentooGroup):
         tar("fxz", test_archive)
 
     def run_tests(self):
-        bzip2 = bb.wrap(bb.path('/bin/bzip2'), self)
+        bzip2 = bb.wrap(local.path('/bin/bzip2'), self)
         bzip2 = bb.watch(bzip2)
 
         # Compress

--- a/benchbuild/projects/gentoo/crafty.py
+++ b/benchbuild/projects/gentoo/crafty.py
@@ -1,6 +1,8 @@
 """
 crafty experiment within gentoo chroot.
 """
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.projects.gentoo.gentoo import GentooGroup
 from benchbuild.utils.cmd import cat
@@ -21,7 +23,7 @@ class Crafty(GentooGroup):
         bb.download.Wget(book_bin, book_file)
 
     def run_tests(self):
-        crafty_path = bb.path("/usr/bin/crafty")
+        crafty_path = local.path("/usr/bin/crafty")
         crafty = bb.wrap(crafty_path, self)
 
         with open("test1.sh", 'w') as test1:

--- a/benchbuild/projects/lnt/lnt.py
+++ b/benchbuild/projects/lnt/lnt.py
@@ -40,24 +40,24 @@ class LNTGroup(bb.Project):
     binary = None
 
     def compile(self):
-        lnt_repo = bb.path(self.source_of('lnt.git'))
-        test_suite_source = bb.path(self.source_of('test-suite'))
+        lnt_repo = local.path(self.source_of('lnt.git'))
+        test_suite_source = local.path(self.source_of('test-suite'))
 
-        venv_path = bb.cwd / "local"
+        venv_path = local.cwd / "local"
         virtualenv(venv_path, "--python=python2")
-        pip_path = bb.cwd / "local" / "bin" / "pip"
+        pip_path = local.cwd / "local" / "bin" / "pip"
         pip = local[pip_path]
 
-        with bb.cwd(lnt_repo):
+        with local.cwd(lnt_repo):
             pip("install", "--no-cache-dir", "--disable-pip-version-check",
                 "-e", ".")
 
-        self.sandbox_dir = bb.cwd / "run"
+        self.sandbox_dir = local.cwd / "run"
         if self.sandbox_dir.exists():
             rm("-rf", self.sandbox_dir)
         mkdir(self.sandbox_dir)
 
-        self.lnt = local[bb.path("./local/bin/lnt")]
+        self.lnt = local[local.path("./local/bin/lnt")]
         self.clang = bb.compiler.cc(self, detect_project=True)
         self.clang_cxx = bb.compiler.cxx(self, detect_project=True)
 
@@ -70,13 +70,13 @@ class LNTGroup(bb.Project):
 
     @staticmethod
     def after_run_tests(sandbox_dir):
-        logfiles = bb.path(sandbox_dir) // "*" / "test.log"
+        logfiles = local.path(sandbox_dir) // "*" / "test.log"
         for log in logfiles:
             LOG.info("Dumping contents of: %s", log)
             (cat[log] & FG)  # pylint: disable=pointless-statement
 
     def run_tests(self):
-        test_suite_source = bb.path(self.source_of('test-suite'))
+        test_suite_source = local.path(self.source_of('test-suite'))
         binary = bb.wrapping.wrap_dynamic(self,
                                           "lnt_runner",
                                           name_filters=LNTGroup.NAME_FILTERS)

--- a/benchbuild/projects/polybench/polybench-mod.py
+++ b/benchbuild/projects/polybench/polybench-mod.py
@@ -1,3 +1,5 @@
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.projects.polybench.polybench import PolyBenchGroup
 from benchbuild.settings import CFG
@@ -16,7 +18,7 @@ class PolybenchModGroup(PolyBenchGroup):
     ]
 
     def compile(self):
-        polybench_repo = bb.path(self.source_of('polybench.git'))
+        polybench_repo = local.path(self.source_of('polybench.git'))
 
         polybench_opts = CFG["projects"]["polybench"]
         verify = bool(polybench_opts["verify"])

--- a/benchbuild/projects/polybench/polybench.py
+++ b/benchbuild/projects/polybench/polybench.py
@@ -1,5 +1,7 @@
 import logging
 
+from plumbum import local
+
 import benchbuild as bb
 from benchbuild.settings import CFG
 from benchbuild.source import HTTP
@@ -103,7 +105,7 @@ class PolyBenchGroup(bb.Project):
         return polybench_opts
 
     def compile(self):
-        polybench_source = bb.path(self.source_of('polybench.tar.gz'))
+        polybench_source = local.path(self.source_of('polybench.tar.gz'))
         polybench_version = self.version_of('polybench.tar.gz')
 
         polybench_opts = CFG["projects"]["polybench"]
@@ -112,7 +114,7 @@ class PolyBenchGroup(bb.Project):
 
         tar('xfz', polybench_source)
 
-        src_dir = bb.path(f'./polybench-c-{polybench_version}')
+        src_dir = local.path(f'./polybench-c-{polybench_version}')
         src_sub = src_dir / self.path_dict[self.name] / self.name
 
         src_file = src_sub / (self.name + ".c")
@@ -145,7 +147,7 @@ class PolyBenchGroup(bb.Project):
         polybench_opts = CFG["projects"]["polybench"]
         verify = bool(polybench_opts["verify"])
 
-        binary = bb.cwd / self.name
+        binary = local.cwd / self.name
         opt_stderr_raw = binary + ".stderr"
         opt_stderr_filtered = opt_stderr_raw + ".filtered"
 
@@ -156,11 +158,11 @@ class PolyBenchGroup(bb.Project):
         filter_stderr(opt_stderr_raw, opt_stderr_filtered)
 
         if verify:
-            binary = bb.cwd / (self.name + ".no-opts")
+            binary = local.cwd / (self.name + ".no-opts")
             noopt_stderr_raw = binary + ".stderr"
             noopt_stderr_filtered = noopt_stderr_raw + ".filtered"
 
-            with bb.env(BB_IS_BASELINE=True):
+            with local.env(BB_IS_BASELINE=True):
                 polybench_bin = bb.wrap(binary, self)
                 _polybench_bin = bb.watch(polybench_bin)
                 _polybench_bin()


### PR DESCRIPTION
Plumbum uses the local machine object in conjunction with StaticProperty wrapper
classes that rely on Python's Object Model to work.

Example:
  If we want to 'alias' plumbum's local.cwd, we would normally do it like this:
    cwd = plumbum.local.cwd
  However, this wwill trigger a property lookup on the local object. This will
  assign the value of the current working directory, instead of the 'cwd' method
  of the local Singleton object.

This reverts the aliasing and removes it from benchbuild's public API.

Client code needs to perform a search-and-replace as follows:
  s/bb.path/local.path/g
  s/bb.env/local.env/g
  s/bb.cwd/local.cwd/g

Furthermore, make sure you import the local Singleton from plumbum in your code:
  from plumbum import local.