### PR TITLE
project: fail, if the user forgets to set a compiler_extension

### DIFF
--- a/benchbuild/extensions/__init__.py
+++ b/benchbuild/extensions/__init__.py
@@ -1,3 +1,4 @@
 from . import base, compiler, log, run, time
 
 Extension = base.Extension
+MissingExtension = base.MissingExtension

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -29,7 +29,7 @@ from plumbum import local
 from plumbum.path.local import LocalPath
 from pygtrie import StringTrie
 
-from benchbuild import source
+from benchbuild import extensions, source
 from benchbuild.settings import CFG
 from benchbuild.utils import db, run, unionfs
 from benchbuild.utils.requirements import Requirement
@@ -230,7 +230,8 @@ class Project(metaclass=ProjectDecorator):
     def __default_primary_source(self) -> str:
         return source.primary(*self.source).key
 
-    compiler_extension = attr.ib(default=None)
+    compiler_extension = attr.ib(
+        default=attr.Factory(extensions.MissingExtension, takes_self=False))
 
     runtime_extension = attr.ib(default=None)
 

--- a/tests/test_missing_extension.py
+++ b/tests/test_missing_extension.py
@@ -1,0 +1,56 @@
+import pytest
+
+from benchbuild import extensions, project, source
+
+
+class DummyPrj(project.Project):
+    NAME: str = 'TestMissingExtension'
+    GROUP: str = 'TestMissingExtension'
+    DOMAIN: str = 'TestMissingExtension'
+    SOURCE = [source.nosource()]
+
+    def run_tests(self):
+        raise NotImplementedError()
+
+
+def describe_missing_extensions():
+    """
+    The user has to provide at least a compiler_extension.
+
+    This enables compilation experiments by default. Runtime experiments
+    can remain fully optional. These typically require external assets as
+    test input and are more complicated to design.
+
+    However, projects are not responsible for the configuration of an extension.
+    This has to be done by an experirment. We could have opted for a mandatory
+    initialization argument to each project. This would break all existing
+    setups and require a more complicated initialization sequence for projects
+    inside an experiment.
+
+    Given that we have to provide documentation about this anyway, we might
+    as well fail dynamically, if the user forgets to configure it. We won't
+    make any assumptions about the quality/types of the 'extensions'. This
+    can be enforced on the project level using attr's validators.
+    """
+
+    def missing_compiler_extension_fails():
+        """
+        If the user forgets to configure the runtime extension, we fail hard.
+        """
+        prj = DummyPrj()
+        ext = prj.compiler_extension
+
+        with pytest.raises(extensions.base.ExtensionRequired):
+            ext()
+
+    def any_user_configured_extension_does_not_fail():
+        """
+        As long as the user sets *anything* we are fine for now.
+
+        This, obviously, won't do anything useful.
+        """
+        prj = DummyPrj()
+        prj.compiler_extension = lambda: True
+        ext = prj.compiler_extension
+
+        assert ext()


### PR DESCRIPTION
## What

Projects are not responsible for the configuration of an extension. This has to be done by an experirment.
We could have opted for a mandatory initialization argument to each project, but
this would break all existing setups and require a more complicated initialization sequence for projects inside an experiment.

In this PR, we will enforce a hard-fail at runtime, if the compiler_extension has not been changed from the default.

## Why

The decoupling of experiments and projects in PR #287 required project/experiment developers to define their
own compiler_extension. Before this PR we provided a default setup of a retrying compilation scheme. Now, nobody
will notice a missing compiler_extension and encounter crypted stack traces from benchbuild.

## Migration

This PR does not change end-user facing behavior. It will fail hard with an ExtensionRequired exception, if you forget to set
anything but the default to a project's compiler_extension.
