### PR TITLE
fix: add slurm test to list of integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         coverage run -p `which benchbuild` project view
         coverage run -p `which benchbuild` experiment view
         coverage run -p `which benchbuild` -vvvvv run --full test
+        coverage run -p `which benchbuild` -vvvvv slurm -E empty test
         coverage combine -a
         coverage xml
 

--- a/benchbuild/utils/slurm.py
+++ b/benchbuild/utils/slurm.py
@@ -57,7 +57,7 @@ def __expand_project_versions__(experiment: Experiment) -> Iterable[str]:
 
     for _, project_type in project_types.items():
         for variant in experiment.sample(project_type):
-            project = project_type(experiment, variant=variant)
+            project = project_type(variant=variant)
             expanded.append(project.id)
     return expanded
 


### PR DESCRIPTION
## What

This adds an example slurm command to the list of integration tests.

## Why

Due to design defects in the handling of run/slurm subcommands, we will often break one or the other. The lack
of integration tests on the SLURM side will let these slip through.

This fixes #299 