### PR TITLE
containers: add domain support for mountpoints on container creation

### DIFF
--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -99,7 +99,17 @@ def update_env_layer(
     cmd(container.container_id)
 
 
-def fetch_image_env(image: model.Image):
+def fetch_image_env(image: model.Image) -> None:
+    """
+    Fetch the configured environment vars for this image.
+
+    Reconstructs an environment dictionary from the configured container
+    image enviornment. The image will be updated in-place. Existing values
+    will be overwritten.
+
+    Args:
+        image: The image to fetch the env for.
+    """
     results = json.loads(BB_BUILDAH_INSPECT(image.name))
     oci_config = {}
 

--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -126,7 +126,6 @@ def fetch_image_env(image: model.Image) -> None:
 
     except KeyError:
         return
-    print(image.env)
 
 
 def set_entry_point(

--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -31,10 +31,10 @@ BB_BUILDAH_CONFIG: BaseCommand = bb_buildah()['config']
 BB_BUILDAH_COPY: BaseCommand = bb_buildah(
 )['copy'][BUILDAH_DEFAULT_COMMAND_OPTS]
 BB_BUILDAH_IMAGES: BaseCommand = bb_buildah()['images']
+BB_BUILDAH_INSPECT: BaseCommand = bb_buildah()['inspect']
 BB_BUILDAH_RUN: BaseCommand = bb_buildah()['run'][BUILDAH_DEFAULT_COMMAND_OPTS]
 BB_BUILDAH_RM: BaseCommand = bb_buildah()['rm']
 BB_BUILDAH_CLEAN: BaseCommand = bb_buildah()['clean']
-BB_BUILDAH_INSPECT: BaseCommand = bb_buildah()['inspect']
 
 
 def create_build_context() -> local.path:
@@ -99,6 +99,26 @@ def update_env_layer(
     cmd(container.container_id)
 
 
+def fetch_image_env(image: model.Image):
+    results = json.loads(BB_BUILDAH_INSPECT(image.name))
+    oci_config = {}
+
+    try:
+        if results:
+            oci_config = results['OCIv1']['config']
+
+        if oci_config:
+            env_list = oci_config.get('Env')
+            if env_list:
+                for env_item in env_list:
+                    k, v = env_item.split('=')
+                    image.env[k] = v
+
+    except KeyError:
+        return
+    print(image.env)
+
+
 def set_entry_point(
     container: model.Container, layer: model.EntryPoint
 ) -> None:
@@ -123,7 +143,9 @@ def find_image(tag: str) -> model.MaybeImage:
         json_results = json.loads(results)
         if json_results:
             #json_image = json_results.pop(0)
-            return model.Image(tag, model.FromLayer(tag), [])
+            image = model.Image(tag, model.FromLayer(tag), [])
+            fetch_image_env(image)
+            return image
     return None
 
 

--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -29,19 +29,20 @@ def create_container(
     container_name: str,
     mounts: tp.Optional[tp.List[str]] = None
 ) -> str:
-    create_cmd = BB_PODMAN_CREATE['--replace', '--name']
+    create_cmd = BB_PODMAN_CREATE['--replace']
 
     if mounts:
         for mount in mounts:
             create_cmd = create_cmd['--mount', mount]
 
-    cfg_mounts = CFG['container']['mounts'].value()
+    cfg_mounts = list(CFG['container']['mounts'].value)
     if cfg_mounts:
         for source, target in cfg_mounts:
             create_cmd = create_cmd['--mount', f'{source}:{target}']
 
-    container_id = str(create_cmd(container_name.lower(),
-                                  image_id.lower())).strip()
+    container_id = str(
+        create_cmd('--name', container_name.lower(), image_id.lower())
+    ).strip()
 
     LOG.debug('created container: %s', container_id)
     return container_id

--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -29,7 +29,18 @@ def create_container(
     container_name: str,
     mounts: tp.Optional[tp.List[str]] = None
 ) -> str:
-    create_cmd = BB_PODMAN_CREATE['--replace']
+    """
+    Create, but do not start, an OCI container.
+
+    Refer to 'buildah create --help' for details about mount
+    specifications and '--replace'.
+
+    Args:
+        image_id: The container image used as template.
+        container_name: The name the container will be given.
+        mounts: A list of mount specifications for the OCI runtime.
+    """
+    create_cmd = BB_PODMAN_CREATE['--replace', '--name']
 
     if mounts:
         for mount in mounts:

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -1,5 +1,3 @@
-import typing as tp
-
 import attr
 
 from . import declarative

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -1,3 +1,5 @@
+import typing as tp
+
 import attr
 
 from . import declarative
@@ -41,9 +43,11 @@ class CreateBenchbuildBase(Command):
 
 
 @attr.s(frozen=True, hash=False)
-class RunContainer(Command):
+class RunProjectContainer(Command):
     image: str = attr.ib()
     name: str = attr.ib()
+
+    build_dir: str = attr.ib()
 
 
 # pylint: enable=too-few-public-methods

--- a/benchbuild/environments/domain/model.py
+++ b/benchbuild/environments/domain/model.py
@@ -109,6 +109,15 @@ class SetCommand(Layer):
         return f'CMD {command}'
 
 
+@attr.s(frozen=True)
+class Mount:
+    source: str = attr.ib()
+    target: str = attr.ib()
+
+    def __str__(self) -> str:
+        return f'{self.source}:{self.target}'
+
+
 @attr.s(eq=False)
 class Image:
     name: str = attr.ib()
@@ -116,6 +125,7 @@ class Image:
     layers: tp.List[Layer] = attr.ib()
     events = attr.ib(attr.Factory(list))  # type: tp.List[events.Event]
     env = attr.ib(attr.Factory(dict))  # type: tp.Dict[str, str]
+    mounts: tp.List[Mount] = attr.ib(attr.Factory(list))
 
     def update_env(self, **kwargs: str) -> None:
         self.env.update(kwargs)

--- a/benchbuild/environments/service_layer/handlers.py
+++ b/benchbuild/environments/service_layer/handlers.py
@@ -61,9 +61,13 @@ def create_benchbuild_base(
         return str(image.name)
 
 
-def run_experiment_images(
-    cmd: commands.RunContainer, uow: unit_of_work.AbstractUnitOfWork
+def run_project_container(
+    cmd: commands.RunProjectContainer, uow: unit_of_work.AbstractUnitOfWork
 ) -> None:
     with uow:
+        build_dir = uow.registry.env(cmd.image, 'BB_BUILD_DIR')
+        uow.registry.temporary_mount(
+            cmd.image, cmd.build_dir, build_dir if build_dir else '.'
+        )
         container = uow.create_container(cmd.image, cmd.name)
         uow.run_container(container)

--- a/benchbuild/environments/service_layer/messagebus.py
+++ b/benchbuild/environments/service_layer/messagebus.py
@@ -99,5 +99,5 @@ COMMAND_HANDLERS = {
     commands.CreateImage: handlers.create_image,
     commands.UpdateImage: handlers.update_image,
     commands.CreateBenchbuildBase: handlers.create_benchbuild_base,
-    commands.RunContainer: handlers.run_experiment_images
+    commands.RunProjectContainer: handlers.run_project_container
 }

--- a/benchbuild/environments/service_layer/unit_of_work.py
+++ b/benchbuild/environments/service_layer/unit_of_work.py
@@ -9,7 +9,7 @@ class AbstractUnitOfWork(abc.ABC):
     registry: repository.AbstractRegistry
 
     def collect_new_events(self) -> tp.Generator[events.Event, None, None]:
-        for image in self.registry.images:
+        for image in self.registry.images.values():
             while image.events:
                 yield image.events.pop(0)
 


### PR DESCRIPTION
This adds support in the containers domain for mountpoints from multiple
sources. We support 2 ways to provide mountpoints to containers:

1. Through settings: Using config key 'container->mounts'
   This provides global mountpoints in as a list of tuples to containers

2. Through the project environment: During container creation, the instantiated
   project defines a build directory to provide the external build directory as
   mount point.