### PR TITLE
Validate container and image names at the edge

### DIFF
--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -52,9 +52,7 @@ def create_container(
             create_cmd = create_cmd['--mount',
                                     f'type=bind,src={source},target={target}']
 
-    container_id = str(
-        create_cmd('--name', container_name.lower(), image_id.lower())
-    ).strip()
+    container_id = str(create_cmd('--name', container_name, image_id)).strip()
 
     LOG.debug('created container: %s', container_id)
     return container_id

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -10,6 +10,15 @@ def oci_compliant_name(name: str) -> str:
     For now, we just make sure it is lower-case. This is depending on
     the implementation of your container registry. podman/buildah require
     lower-case repository names for now.
+
+    Args:
+        name: the name to convert
+
+    Examples:
+        >>> oci_compliant_name("foo")
+        'foo'
+        >>> oci_compliant_name("FoO")
+        'FoO'
     """
     # OCI Spec requires image names to be lowercase
     return name.lower()

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -2,6 +2,19 @@ import attr
 
 from . import declarative
 
+
+def oci_compliant_name(name: str) -> str:
+    """
+    Convert a name to an OCI compliant name.
+
+    For now, we just make sure it is lower-case. This is depending on
+    the implementation of your container registry. podman/buildah require
+    lower-case repository names for now.
+    """
+    # OCI Spec requires image names to be lowercase
+    return name.lower()
+
+
 #
 # Dataclasses are perfectly valid without public methods
 #
@@ -15,7 +28,7 @@ class Command:
 
 @attr.s(frozen=True, hash=False)
 class CreateImage(Command):
-    name: str = attr.ib()
+    name: str = attr.ib(converter=oci_compliant_name)
     layers: declarative.ContainerImage = attr.ib()
 
     def __hash__(self) -> int:
@@ -24,7 +37,7 @@ class CreateImage(Command):
 
 @attr.s(frozen=True, hash=False)
 class UpdateImage(Command):
-    name: str = attr.ib()
+    name: str = attr.ib(converter=oci_compliant_name)
     layers: declarative.ContainerImage = attr.ib()
 
     def __hash__(self) -> int:
@@ -33,7 +46,7 @@ class UpdateImage(Command):
 
 @attr.s(frozen=True, hash=False)
 class CreateBenchbuildBase(Command):
-    name: str = attr.ib(eq=True)
+    name: str = attr.ib(converter=oci_compliant_name, eq=True)
     layers: declarative.ContainerImage = attr.ib()
 
     def __hash__(self) -> int:
@@ -42,8 +55,8 @@ class CreateBenchbuildBase(Command):
 
 @attr.s(frozen=True, hash=False)
 class RunProjectContainer(Command):
-    image: str = attr.ib()
-    name: str = attr.ib()
+    image: str = attr.ib(converter=oci_compliant_name)
+    name: str = attr.ib(converter=oci_compliant_name)
 
     build_dir: str = attr.ib()
 

--- a/benchbuild/environments/entrypoints/cli.py
+++ b/benchbuild/environments/entrypoints/cli.py
@@ -221,6 +221,10 @@ def run_experiment_images(
         experiments: Index of experiments to run.
         projects: Index of projects to run.
     """
+
+    build_dir = str(CFG['build_dir'])
+    uow = unit_of_work.ContainerImagesUOW()
+
     for exp in enumerate_experiments(experiments, projects):
         for prj in exp.projects:
             version = make_version_tag(*prj.variant.values())
@@ -230,10 +234,8 @@ def run_experiment_images(
 
             container_name = f'{exp.name}_{prj.name}_{prj.group}'
 
-            build_dir = str(CFG['build_dir'])
             cmd = commands.RunProjectContainer(
                 image_tag, container_name, build_dir
             )
-            uow = unit_of_work.ContainerImagesUOW()
 
             messagebus.handle(cmd, uow)

--- a/benchbuild/environments/service_layer/ensure.py
+++ b/benchbuild/environments/service_layer/ensure.py
@@ -1,0 +1,19 @@
+import typing as tp
+
+from benchbuild.environments.domain import commands
+
+from . import unit_of_work
+
+
+class ImageNotFound(Exception):
+
+    def __init__(self, message: tp.Any):
+        self.message = message
+
+
+def image_exists(
+    cmd: commands.RunProjectContainer, uow: unit_of_work.AbstractUnitOfWork
+) -> None:
+    image = uow.registry.get_image(cmd.name)
+    if not image:
+        raise ImageNotFound(cmd)

--- a/benchbuild/environments/service_layer/ensure.py
+++ b/benchbuild/environments/service_layer/ensure.py
@@ -1,18 +1,21 @@
 import typing as tp
 
-from benchbuild.environments.domain import commands
-
 from . import unit_of_work
 
 
 class ImageNotFound(Exception):
+    ...
 
-    def __init__(self, message: tp.Any):
-        self.message = message
+
+class NamedCommand(tp.Protocol):
+
+    @property
+    def name(self) -> str:
+        ...
 
 
 def image_exists(
-    cmd: commands.RunProjectContainer, uow: unit_of_work.AbstractUnitOfWork
+    cmd: NamedCommand, uow: unit_of_work.AbstractUnitOfWork
 ) -> None:
     image = uow.registry.get_image(cmd.name)
     if not image:

--- a/benchbuild/environments/service_layer/handlers.py
+++ b/benchbuild/environments/service_layer/handlers.py
@@ -71,6 +71,9 @@ def create_benchbuild_base(
 def run_project_container(
     cmd: commands.RunProjectContainer, uow: unit_of_work.AbstractUnitOfWork
 ) -> None:
+    """
+    Run a project container.
+    """
     with uow:
         ensure.image_exists(cmd, uow)
 

--- a/benchbuild/environments/service_layer/messagebus.py
+++ b/benchbuild/environments/service_layer/messagebus.py
@@ -84,6 +84,7 @@ def handle_command(
         queue.extend(uow.collect_new_events())
     except Exception:
         LOG.exception('Exception handling command %s', command)
+        raise
 
 
 EVENT_HANDLERS = {

--- a/tests/environments/domain/test_commands.py
+++ b/tests/environments/domain/test_commands.py
@@ -1,0 +1,26 @@
+"""Test command validation & conversion."""
+from benchbuild.environments.domain import commands, declarative
+
+
+def describe_image_commands():
+
+    def name_is_lowercase():
+        expected = ['test-1', 'test-2', 'test-3']
+
+        cmd_1 = commands.CreateBenchbuildBase(
+            'TEST-1', declarative.ContainerImage()
+        )
+        cmd_2 = commands.UpdateImage('TEST-2', declarative.ContainerImage())
+        cmd_3 = commands.CreateImage('TEST-3', declarative.ContainerImage())
+
+        assert [cmd_1.name, cmd_2.name, cmd_3.name] == expected
+
+
+def describe_container_commands():
+
+    def image_name_is_lowercase():
+        expected = ['test-1', 'containername1']
+
+        cmd_1 = commands.RunProjectContainer('TEST-1', 'ContainerName1', '')
+
+        assert [cmd_1.image, cmd_1.name] == expected


### PR DESCRIPTION
This fixes #323 

We perform validation at our API edge and make sure that our names for containers and images are oci compliant (-ish). For now this just means lowercase them all.