### PR TITLE
Add support for GitSubmodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
         pip install -r requirements.txt
+        pip install -r test-requirements.txt
         pip install codecov
         pip install pytest
         pip install pytest-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
         pip install .
         pip install -r requirements.txt
         pip install -r test-requirements.txt
-        pip install codecov
-        pip install pytest
-        pip install pytest-cov
-        pip install pytest-describe
 
     - name: Test bootstrapping
       run: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = attr,dill,jinja2,migrate,parse,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,yaml
+known_third_party = attr,dill,git,jinja2,migrate,parse,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,testdata,yaml
 multi_line_output=3
 use_parentheses = True
 include_trailing_comma: True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = attr,dill,jinja2,migrate,parse,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,typing_extensions,yaml
+known_third_party = attr,dill,jinja2,migrate,parse,pathos,pkg_resources,plumbum,psutil,pygit2,pygtrie,pyparsing,pytest,rich,setuptools,six,sqlalchemy,yaml
 multi_line_output=3
 use_parentheses = True
 include_trailing_comma: True

--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 bad-functions=map,filter
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=a,c,d,e,f,i,j,k,p,q,r,v,bb,cc,ex,fd,id,qr,ri,ro,rw,to,xz,cmd,cwd,env,path,Copy,CopyNoFail,From,Git,OK,Rsync,Run,Session,Svn,To,Wget,_,T
+good-names=a,c,d,e,f,i,j,k,p,q,r,v,bb,cc,ex,fd,id,qr,ri,ro,rw,to,xz,cmd,cwd,env,path,Copy,CopyNoFail,From,Git,OK,Rsync,Run,Session,Svn,To,Wget,_
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/.pylintrc
+++ b/.pylintrc
@@ -56,7 +56,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 bad-functions=map,filter
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=a,c,d,e,f,i,j,k,p,q,r,v,bb,cc,ex,fd,id,qr,ri,ro,rw,to,xz,cmd,cwd,env,path,Copy,CopyNoFail,From,Git,OK,Rsync,Run,Session,Svn,To,Wget,_
+good-names=a,c,d,e,f,i,j,k,p,q,r,v,bb,cc,ex,fd,id,qr,ri,ro,rw,to,xz,cmd,cwd,env,path,Copy,CopyNoFail,From,Git,OK,Rsync,Run,Session,Svn,To,Wget,_,T
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
@@ -264,7 +264,7 @@ callbacks=cb_,_cb
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,__new__,__attrs_post_init__,setUp
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls
@@ -279,13 +279,13 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 [DESIGN]
 
-max-args=5
+max-args=8
 ignored-argument-names=_.*
 max-locals=15
 max-returns=6
 max-branches=12
 max-statements=50
-max-parents=7
+max-parents=10
 max-attributes=7
 min-public-methods=1
 max-public-methods=20

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -42,7 +42,7 @@ LOG = logging.getLogger(__name__)
 MaybeGroupNames = tp.Optional[tp.List[str]]
 ProjectNames = tp.List[str]
 VariantContext = source.VariantContext
-Sources = tp.List[source.base.ISource]
+Sources = tp.List[source.FetchableSource]
 ContainerDeclaration = tp.Union[ContainerImage,
                                 tp.List[tp.Tuple[RevisionRange,
                                                  ContainerImage]]]
@@ -327,7 +327,7 @@ class Project(metaclass=ProjectDecorator):
             name (str): Local name of the source .
 
         Returns:
-            (Optional[BaseSource]): A source representing this variant.
+            (Optional[FetchableSource]): A source representing this variant.
         """
         variant = self.variant
         if name in variant:
@@ -343,7 +343,7 @@ class Project(metaclass=ProjectDecorator):
             name (str): Local name of the source .
 
         Returns:
-            (Optional[BaseSource]): A source representing this variant.
+            (Optional[FetchableSource]): A source representing this variant.
         """
         variant = self.variant
         if name in variant:
@@ -415,11 +415,12 @@ def __add_named_filters__(
     project: ProjectT, versions: tp.Dict[str, str]
 ) -> ProjectT:
     sources = project.SOURCE
-    named_sources: tp.Dict[str,
-                           source.base.ISource] = {s.key: s for s in sources}
+    named_sources: tp.Dict[str, source.base.FetchableSource] = {
+        s.key: s for s in sources
+    }
     for k, v in versions.items():
         if k in named_sources:
-            victim: source.base.ISource = named_sources[k]
+            victim: source.base.FetchableSource = named_sources[k]
             victim = source.SingleVersionFilter(victim, v)
             named_sources[k] = victim
     sources = list(named_sources.values())

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -322,6 +322,11 @@ class Project(metaclass=ProjectDecorator):
         """
         Retrieve source for given index name.
 
+        First we try to find the given source in the configured variant index.
+        If unsuccessful, we try to find them in our configured sources. The
+        second variant picks up all sources that did not take part in
+        version expansion.
+
         Args:
             project (Project): The project to access.
             name (str): Local name of the source .
@@ -332,6 +337,11 @@ class Project(metaclass=ProjectDecorator):
         variant = self.variant
         if name in variant:
             return str(self.builddir / variant[name].owner.local)
+
+        all_sources = source.sources_as_dict(*self.source)
+        if name in all_sources:
+            return str(self.builddir / all_sources[name].local)
+
         return None
 
     def version_of(self, name: str) -> tp.Optional[str]:

--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -10,6 +10,7 @@ from .base import default as default
 from .base import nosource as nosource
 from .base import primary as primary
 from .base import product as product
+from .base import sources_as_dict as sources_as_dict
 from .base import to_str as to_str
 from .git import Git as Git
 from .git import GitSubmodule as GitSubmodule

--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -2,7 +2,7 @@
 """
 Declarative API for downloading sources required by benchbuild.
 """
-from .base import BaseSource as BaseSource
+from .base import FetchableSource as FetchableSource
 from .base import Variant as Variant
 from .base import VariantContext as VariantContext
 from .base import context as context

--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -12,6 +12,7 @@ from .base import primary as primary
 from .base import product as product
 from .base import to_str as to_str
 from .git import Git as Git
+from .git import GitSubmodule as GitSubmodule
 from .http import HTTP as HTTP
 from .versions import BaseVersionFilter as BaseVersionFilter
 from .versions import BaseVersionGroup as BaseVersionGroup

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -289,3 +289,18 @@ def product(*sources: Expandable) -> NestedVariants:
     """
     siblings = [source.versions() for source in sources if source.is_expandable]
     return itertools.product(*siblings)
+
+
+SourceContext = tp.Dict[str, Fetchable]
+
+
+def sources_as_dict(*sources: Fetchable) -> SourceContext:
+    """
+    Convert fetchables to a dictionary.
+
+    The dictionary will be indexed by the Fetchable's local attribute.
+
+    Args:
+        *sources: Fetchables stored in the dictionary.
+    """
+    return {src.local: src for src in sources}

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -264,10 +264,10 @@ def default(*sources: Versioned) -> VariantContext:
     return context(*first)
 
 
-T = tp.TypeVar('T')
+SourceT = tp.TypeVar('T')
 
 
-def primary(*sources: T) -> T:
+def primary(*sources: SourceT) -> SourceT:
     """
     Return the implicit 'main' source of a project.
 

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -3,12 +3,18 @@ Provide a base interface for downloadable sources.
 """
 import abc
 import itertools
+import sys
 import typing as tp
 
 import attr
 import plumbum as pb
 
 from benchbuild.settings import CFG
+
+if sys.version_info <= (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
 
 NestedVariants = tp.Iterable[tp.Tuple[tp.Any, ...]]
 
@@ -61,7 +67,7 @@ def to_str(*variants: Variant) -> str:
     return ",".join([str(i) for i in variants])
 
 
-class Fetchable(tp.Protocol):
+class Fetchable(Protocol):
 
     @property
     def key(self) -> str:
@@ -91,7 +97,7 @@ class Fetchable(tp.Protocol):
         ...
 
 
-class Expandable(tp.Protocol):
+class Expandable(Protocol):
 
     @property
     def is_expandable(self) -> bool:
@@ -113,7 +119,7 @@ class Expandable(tp.Protocol):
         ...
 
 
-class Versioned(tp.Protocol):
+class Versioned(Protocol):
 
     @property
     def default(self) -> Variant:

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -264,7 +264,7 @@ def default(*sources: Versioned) -> VariantContext:
     return context(*first)
 
 
-SourceT = tp.TypeVar('T')
+SourceT = tp.TypeVar('SourceT')
 
 
 def primary(*sources: SourceT) -> SourceT:

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -168,6 +168,8 @@ class FetchableSource(Fetchable, Expandable, Versioned):
     _remote: tp.Union[str, tp.Dict[str, str]]
 
     def __init__(self, local: str, remote: tp.Union[str, tp.Dict[str, str]]):
+        super().__init__()
+
         self._local = local
         self._remote = remote
 

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -29,7 +29,7 @@ class Variant:
     same way as a program variant like a specific configuraiton.
     """
 
-    owner: 'BaseSource' = attr.ib(eq=False, repr=False)
+    owner: 'FetchableSource' = attr.ib(eq=False, repr=False)
     version: str = attr.ib()
 
     def __str__(self) -> str:
@@ -61,23 +61,9 @@ def to_str(*variants: Variant) -> str:
     return ",".join([str(i) for i in variants])
 
 
-class ISource(abc.ABC):
+class Fetchable(tp.Protocol):
 
-    @abc.abstractproperty
-    def local(self) -> str:
-        """
-        The source location (path-like) after fetching it from its remote.
-        """
-        raise NotImplementedError()
-
-    @abc.abstractproperty
-    def remote(self) -> tp.Union[str, tp.Dict[str, str]]:
-        """
-        The source location in the remote location.
-        """
-        raise NotImplementedError()
-
-    @abc.abstractproperty
+    @property
     def key(self) -> str:
         """
         Return the source's key property.
@@ -88,16 +74,54 @@ class ISource(abc.ABC):
         While this make no further assumption, but a good candidate is a
         file-system name/path.
         """
-        raise NotImplementedError()
+        ...
 
-    @abc.abstractproperty
+    @property
+    def local(self) -> str:
+        """
+        The source location (path-like) after fetching it from its remote.
+        """
+        ...
+
+    @property
+    def remote(self) -> tp.Union[str, tp.Dict[str, str]]:
+        """
+        The source location in the remote location.
+        """
+        ...
+
+
+class Expandable(tp.Protocol):
+
+    @property
+    def is_expandable(self) -> bool:
+        """
+        Returns true, if this source should take part in version expansion.
+
+        Some sources may only be treated as virtual and would not take part
+        in the version expansion of an associated project.
+        """
+        ...
+
+    def versions(self) -> tp.Iterable[Variant]:
+        """
+        List all available versions of this source.
+
+        Returns:
+            List[str]: The list of all available versions.
+        """
+        ...
+
+
+class Versioned(tp.Protocol):
+
+    @property
     def default(self) -> Variant:
         """
         The default version for this source.
         """
-        raise NotImplementedError()
+        ...
 
-    @abc.abstractmethod
     def version(self, target_dir: str, version: str) -> pb.LocalPath:
         """
         Fetch the requested version and place it in the target_dir
@@ -111,9 +135,9 @@ class ISource(abc.ABC):
         Returns:
             str: [description]
         """
-        raise NotImplementedError()
+        ...
 
-    @abc.abstractmethod
+    @property
     def versions(self) -> tp.Iterable[Variant]:
         """
         List all available versions of this source.
@@ -121,17 +145,25 @@ class ISource(abc.ABC):
         Returns:
             List[str]: The list of all available versions.
         """
-        raise NotImplementedError()
+        ...
 
 
-@attr.s
-class BaseSource(ISource):
+class FetchableSource(Fetchable, Expandable, Versioned):
     """
-    Base class for downloadable sources.
+    Base class for fetchable sources.
+
+    Subclasses have to provide the following protocols:
+      - Expandable
+      - Fetchable
+      - Versioned
     """
 
-    _local: str = attr.ib()
-    _remote: tp.Union[str, tp.Dict[str, str]] = attr.ib()
+    _local: str
+    _remote: tp.Union[str, tp.Dict[str, str]]
+
+    def __init__(self, local: str, remote: tp.Union[str, tp.Dict[str, str]]):
+        self._local = local
+        self._remote = remote
 
     @property
     def local(self) -> str:
@@ -178,12 +210,15 @@ class BaseSource(ISource):
         """
         raise NotImplementedError()
 
+    @property
+    def is_expandable(self) -> bool:
+        return True
 
-Sources = tp.List['BaseSource']
+
+Sources = tp.List['FetchableSource']
 
 
-@attr.s
-class NoSource(BaseSource):
+class NoSource(FetchableSource):
 
     @property
     def default(self) -> Variant:
@@ -197,7 +232,7 @@ class NoSource(BaseSource):
 
 
 def nosource() -> NoSource:
-    return NoSource(local='NoSource', remote='NoSource')
+    return NoSource('NoSource', 'NoSource')
 
 
 def target_prefix() -> str:
@@ -210,7 +245,7 @@ def target_prefix() -> str:
     return str(CFG['tmp_dir'])
 
 
-def default(*sources: ISource) -> VariantContext:
+def default(*sources: Versioned) -> VariantContext:
     """
     Return the collective 'default' version for the given sources.
 
@@ -221,7 +256,10 @@ def default(*sources: ISource) -> VariantContext:
     return context(*first)
 
 
-def primary(*sources: ISource) -> ISource:
+T = tp.TypeVar('T')
+
+
+def primary(*sources: T) -> T:
     """
     Return the implicit 'main' source of a project.
 
@@ -234,12 +272,12 @@ def primary(*sources: ISource) -> ISource:
     return head
 
 
-def product(*sources: ISource) -> NestedVariants:
+def product(*sources: Expandable) -> NestedVariants:
     """
     Return the cross product of the given sources.
 
     Returns:
         An iterable containing the cross product of all source variants.
     """
-    siblings = [source.versions() for source in sources]
+    siblings = [source.versions() for source in sources if source.is_expandable]
     return itertools.product(*siblings)

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -90,7 +90,7 @@ class Git(base.FetchableSource):
         mkdir('-p', tgt_loc)
         with pb.local.cwd(tgt_loc):
             clone(
-                '--dissociate', '--reference', '--recurse-submodules', src_loc,
+                '--dissociate', '--recurse-submodules', '--reference', src_loc,
                 self.remote, '.'
             )
             checkout('--detach', version)

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -85,7 +85,10 @@ class Git(base.FetchableSource):
 
         mkdir('-p', tgt_loc)
         with pb.local.cwd(tgt_loc):
-            clone('--dissociate', '--reference', src_loc, self.remote, '.')
+            clone(
+                '--dissociate', '--reference', '--recurse-submodules', src_loc,
+                self.remote, '.'
+            )
             checkout('--detach', version)
 
         return tgt_loc

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -1,6 +1,7 @@
 """
 Declare a git source.
 """
+import os
 import typing as tp
 
 import plumbum as pb
@@ -60,7 +61,8 @@ class Git(base.FetchableSource):
         clone = maybe_shallow(
             git['clone', '--recurse-submodules'], self.shallow
         )
-        cache_path = pb.local.path(prefix) / self.local
+        flat_local = self.local.replace(os.sep, '-')
+        cache_path = pb.local.path(prefix) / flat_local
 
         if clone_needed(self.remote, cache_path):
             clone(self.remote, cache_path)

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -57,7 +57,9 @@ class Git(base.FetchableSource):
             str: [description]
         """
         prefix = base.target_prefix()
-        clone = maybe_shallow(git['clone'], self.shallow)
+        clone = maybe_shallow(
+            git['clone', '--recurse-submodules'], self.shallow
+        )
         cache_path = pb.local.path(prefix) / self.local
 
         if clone_needed(self.remote, cache_path):

--- a/benchbuild/source/http.py
+++ b/benchbuild/source/http.py
@@ -3,9 +3,7 @@ Declare a http source.
 """
 import typing as tp
 
-import attr
 import plumbum as pb
-from plumbum import local
 
 from benchbuild.source import base
 from benchbuild.utils.cmd import cp, wget
@@ -14,8 +12,7 @@ VarRemotes = tp.Union[str, tp.Dict[str, str]]
 Remotes = tp.Dict[str, str]
 
 
-@attr.s
-class HTTP(base.BaseSource):
+class HTTP(base.FetchableSource):
     """
     Fetch the downloadable source via http.
     """
@@ -30,12 +27,12 @@ class HTTP(base.BaseSource):
 
         url = remotes[version]
         target_name = versioned_target_name(self.local, version)
-        cache_path = local.path(prefix) / target_name
+        cache_path = pb.local.path(prefix) / target_name
         download_single_version(url, cache_path)
 
         # FIXME: Belongs to environment code.
 
-        target_path = local.path(target_dir) / self.local
+        target_path = pb.local.path(target_dir) / self.local
         cp('-ar', cache_path, target_path)
         return target_path
 

--- a/benchbuild/source/versions.py
+++ b/benchbuild/source/versions.py
@@ -9,6 +9,8 @@ from . import base
 class BaseVersionGroup(base.Versioned):
 
     def __init__(self, children: tp.List[base.FetchableSource]):
+        super().__init__()
+
         self.children = children
 
     @property

--- a/benchbuild/utils/log.py
+++ b/benchbuild/utils/log.py
@@ -34,7 +34,7 @@ def configure():
         3: logging.INFO,
         2: logging.WARNING,
         1: logging.ERROR,
-        0: logging.CRITICAL
+        0: logging.ERROR
     }
 
     logging.captureWarnings(True)

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -7,17 +7,21 @@ import typing as t
 from contextlib import contextmanager
 
 import attr
-import typing_extensions as te
 from plumbum import TEE, local
 from plumbum.commands import ProcessExecutionError
 from plumbum.commands.base import BaseCommand
 
 from benchbuild import settings, signals
 
+if sys.version_info <= (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
+
 CommandResult = t.Tuple[int, str, str]
 
 
-class WatchableCommand(te.Protocol):
+class WatchableCommand(Protocol):
 
     def __call__(self, *args: t.Any, **kwargs: t.Any) -> CommandResult:
         ...

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     package_data={"benchbuild": RESOURCES},
     include_package_data=True,
     setup_requires=["pytest-runner", "setuptools_scm"],
-    tests_require=["pytest", "pytest-describe", "testdata", "gitpython"],
     install_requires=[
         "Jinja2~=2.10", "PyYAML~=5.1", "attrs>=19.3,<21.0", "dill~=0.3",
         "pathos~=0.2", "parse~=1.14", "pdoc3~=0.8", "plumbum~=1.6",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_data={"benchbuild": RESOURCES},
     include_package_data=True,
     setup_requires=["pytest-runner", "setuptools_scm"],
-    tests_require=["pytest", "pytest-describe", "testdata"],
+    tests_require=["pytest", "pytest-describe", "testdata", "gitpython"],
     install_requires=[
         "Jinja2~=2.10", "PyYAML~=5.1", "attrs>=19.3,<21.0", "dill~=0.3",
         "pathos~=0.2", "parse~=1.14", "pdoc3~=0.8", "plumbum~=1.6",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_data={"benchbuild": RESOURCES},
     include_package_data=True,
     setup_requires=["pytest-runner", "setuptools_scm"],
-    tests_require=["pytest", "pytest-describe"],
+    tests_require=["pytest", "pytest-describe", "testdata"],
     install_requires=[
         "Jinja2~=2.10", "PyYAML~=5.1", "attrs>=19.3,<21.0", "dill~=0.3",
         "pathos~=0.2", "parse~=1.14", "pdoc3~=0.8", "plumbum~=1.6",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+codecov
+gitpython
+pytest
+pytest-cov
+pytest-describe
+testdata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import tempfile as tf
 import typing as tp
-from unittest import mock
 
 import git
 import plumbum as pb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import tempfile as tf
+import typing as tp
+from unittest import mock
+
+import git
+import plumbum as pb
+import pytest
+import testdata as td
+
+RepoT = tp.Tuple[pb.local.path, git.Repo]
+
+
+@pytest.fixture
+def mk_git_repo():
+    tmp_dir = pb.local.path(tf.mkdtemp())
+
+    def _git_repository(
+        num_commits: int = 2,
+        git_submodule: tp.Optional[git.Repo] = None
+    ) -> RepoT:
+        nonlocal tmp_dir
+
+        a_repo_name = td.get_file_name()
+        a_repo_base = tmp_dir / a_repo_name
+        repo = git.Repo.init(a_repo_base)
+
+        for _ in range(num_commits):
+            some_content = td.get_str(255)
+            a_name = td.get_file_name()
+            a_file = td.create_file(
+                a_name, contents=some_content, tmpdir=a_repo_base
+            )
+            repo.index.add(a_file)
+            repo.index.commit(f'Add {a_name}')
+
+        if git_submodule:
+            a_sm_path = td.get_file_name()
+            a_sm_name = td.get_file_name()
+            repo.create_submodule(
+                a_sm_name,
+                a_sm_path,
+                url=git_submodule.git_dir,
+                branch='master'
+            )
+            repo.index.commit(
+                f'Add submodule {a_sm_name} to {a_sm_path} from: {repo.git_dir}'
+            )
+
+            return (tmp_dir, repo)
+        return (tmp_dir, repo)
+
+    yield _git_repository
+    tmp_dir.delete()
+
+
+@pytest.fixture
+def simple_repo(mk_git_repo) -> RepoT:
+    yield mk_git_repo()
+
+
+@pytest.fixture
+def repo_with_submodule(mk_git_repo) -> RepoT:
+    base_dir, sub_repo = mk_git_repo()
+    _, main_repo = mk_git_repo(git_submodule=sub_repo)
+
+    yield (base_dir, main_repo)

--- a/tests/e2e/test_git_submodules.py
+++ b/tests/e2e/test_git_submodules.py
@@ -1,0 +1,75 @@
+import typing as tp
+
+import pytest
+
+import benchbuild as bb
+from benchbuild import source, engine
+from benchbuild.environments.domain.declarative import ContainerImage
+from benchbuild.extensions.base import Extension
+from benchbuild.settings import CFG
+from benchbuild.source import Git, GitSubmodule
+from benchbuild.utils import run, log
+
+log.configure()
+log.set_defaults()
+
+
+class NoopExtension(Extension):
+
+    def __call__(self, *args, **kwargs) -> tp.List[run.RunInfo]:
+        return [run.RunInfo()]
+
+
+class ExperimentTest(bb.Experiment):
+    NAME = 'test-experiment'
+    CONTAINER = ContainerImage()
+
+    def actions_for_project(self, project):
+        project.compiler_extension = NoopExtension()
+        project.runtime_extension = NoopExtension()
+        return self.default_runtime_actions(project)
+
+
+class GitSubmoduleTestProject(bb.Project):
+    """
+    E2E Test for GitSubmodule
+    """
+    NAME = 'test-git-submodule'
+    DOMAIN = 'tests'
+    GROUP = 'tests'
+    SOURCE = []
+    CONTAINER = ContainerImage()
+
+    def run_tests(self):
+        pass
+
+    def compile(self):
+        pass
+
+
+@pytest.fixture
+def project_cls(repo_with_submodule):
+    base_dir, repo = repo_with_submodule
+
+    CFG['build_dir'] = str(base_dir)
+    CFG['tmp_dir'] = str(base_dir)
+
+    GitSubmoduleTestProject.SOURCE = [
+        Git(remote=repo.git_dir, local='test.git'),
+        GitSubmodule(remote=repo.submodules[0].url, local='test.git/sub.git')
+    ]
+    return GitSubmoduleTestProject
+
+
+def test_project_creates_variants(project_cls):
+    assert len(list(source.product(*project_cls.SOURCE))) > 0
+
+
+def test_project_environment_with_submodules(project_cls):
+    ngn = engine.Experimentator(
+        experiments=[ExperimentTest], projects=[project_cls]
+    )
+
+    failed = ngn.start()
+
+    assert len(failed) == 0

--- a/tests/e2e/test_git_submodules.py
+++ b/tests/e2e/test_git_submodules.py
@@ -51,6 +51,9 @@ class GitSubmoduleTestProject(bb.Project):
 def project_cls(repo_with_submodule):
     base_dir, repo = repo_with_submodule
 
+    build_dir = str(CFG['build_dir'])
+    tmp_dir = str(CFG['tmp_dir'])
+
     CFG['build_dir'] = str(base_dir)
     CFG['tmp_dir'] = str(base_dir)
 
@@ -58,7 +61,10 @@ def project_cls(repo_with_submodule):
         Git(remote=repo.git_dir, local='test.git'),
         GitSubmodule(remote=repo.submodules[0].url, local='test.git/sub.git')
     ]
-    return GitSubmoduleTestProject
+    yield GitSubmoduleTestProject
+
+    CFG['build_dir'] = build_dir
+    CFG['tmp_dir'] = tmp_dir
 
 
 def test_project_creates_variants(project_cls):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,10 +1,13 @@
 # pylint: disable=redefined-outer-name
+import tempfile as tf
 import typing as tp
 from unittest import mock
 
 import attr
+import git
 import plumbum as pb
 import pytest
+import testdata as td
 
 from benchbuild import source
 from benchbuild.source import FetchableSource, Variant
@@ -179,9 +182,68 @@ def test_versions_product():
     pass
 
 
-def describe_git_submodules():
+RepoT = tp.Tuple[pb.local.path, git.Repo]
 
-    def versions_do_not_get_expanded():
+
+@pytest.fixture
+def mk_git_repo():
+    tmp_dir = pb.local.path(tf.mkdtemp())
+
+    def _git_repository(
+        num_commits: int = 2,
+        git_submodule: tp.Optional[git.Repo] = None
+    ) -> RepoT:
+        nonlocal tmp_dir
+
+        a_repo_name = td.get_file_name()
+        a_repo_base = tmp_dir / a_repo_name
+        repo = git.Repo.init(a_repo_base)
+
+        for _ in range(num_commits):
+            some_content = td.get_str(255)
+            a_name = td.get_file_name()
+            a_file = td.create_file(
+                a_name, contents=some_content, tmpdir=a_repo_base
+            )
+            repo.index.add(a_file)
+            repo.index.commit(f'Add {a_name}')
+
+        if git_submodule:
+            a_sm_path = td.get_file_name()
+            a_sm_name = td.get_file_name()
+            repo.create_submodule(
+                a_sm_name,
+                a_sm_path,
+                url=git_submodule.git_dir,
+                branch='master'
+            )
+            repo.index.commit(
+                f'Add submodule {a_sm_name} to {a_sm_path} from: {repo.git_dir}'
+            )
+
+            return (tmp_dir, repo)
+        return (tmp_dir, repo)
+
+    yield _git_repository
+    tmp_dir.delete()
+
+
+@pytest.fixture
+def simple_repo(mk_git_repo) -> RepoT:
+    yield mk_git_repo()
+
+
+@pytest.fixture
+def repo_with_submodule(mk_git_repo) -> RepoT:
+    base_dir, sub_repo = mk_git_repo()
+    _, main_repo = mk_git_repo(git_submodule=sub_repo)
+
+    yield (base_dir, main_repo)
+
+
+def describe_git():
+
+    def submodule_versions_do_not_get_expanded():
         git_repo = source.Git('remote.git', 'local.git', clone=False)
         git_repo.versions = mock.MagicMock(name='versions')
         git_repo.versions.return_value = ['1', '2', '3']

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 import typing as tp
+from unittest import mock
 
 import attr
 import plumbum as pb
@@ -176,3 +177,22 @@ def test_single_versions_filter(make_source):
 
 def test_versions_product():
     pass
+
+
+def describe_git_submodules():
+
+    def versions_do_not_get_expanded():
+        git_repo = source.Git('remote.git', 'local.git', clone=False)
+        git_repo.versions = mock.MagicMock(name='versions')
+        git_repo.versions.return_value = ['1', '2', '3']
+
+        git_repo_sub = source.GitSubmodule(
+            'remote.sub.git', 'local.git/sub', clone=False
+        )
+        git_repo_sub.versions = mock.MagicMock(name='versions')
+        git_repo_sub.versions.return_value = ['sub1', 'sub2', 'sub3']
+
+        variants = list(source.product(git_repo, git_repo_sub))
+        expected_variants = [('1',), ('2',), ('3',)]
+
+        assert variants == expected_variants

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -294,14 +294,19 @@ def describe_git():
         a_repo.fetch()
 
         for submodule in repo.submodules:
-            expected_sub_path = base_dir / 'outside_main.git'
+            expected_sub_path_outside = base_dir / 'outside_main.git'
+            expected_sub_path_inside = base_dir / 'test.git' / submodule.path
+
             a_sub_repo = source.GitSubmodule(
                 remote=submodule.url, local='outside_main.git'
             )
             a_sub_repo.fetch()
 
-            assert expected_sub_path.exists()
-            assert expected_sub_path.list() != []
+            assert expected_sub_path_outside.exists()
+            assert expected_sub_path_outside.list() != []
+
+            assert expected_sub_path_inside.exists()
+            assert expected_sub_path_inside.list() != []
 
     @mock.patch('benchbuild.source.git.base.target_prefix')
     def submodule_can_be_fetched_inside_fetched_main(

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -182,65 +182,6 @@ def test_versions_product():
     pass
 
 
-RepoT = tp.Tuple[pb.local.path, git.Repo]
-
-
-@pytest.fixture
-def mk_git_repo():
-    tmp_dir = pb.local.path(tf.mkdtemp())
-
-    def _git_repository(
-        num_commits: int = 2,
-        git_submodule: tp.Optional[git.Repo] = None
-    ) -> RepoT:
-        nonlocal tmp_dir
-
-        a_repo_name = td.get_file_name()
-        a_repo_base = tmp_dir / a_repo_name
-        repo = git.Repo.init(a_repo_base)
-
-        for _ in range(num_commits):
-            some_content = td.get_str(255)
-            a_name = td.get_file_name()
-            a_file = td.create_file(
-                a_name, contents=some_content, tmpdir=a_repo_base
-            )
-            repo.index.add(a_file)
-            repo.index.commit(f'Add {a_name}')
-
-        if git_submodule:
-            a_sm_path = td.get_file_name()
-            a_sm_name = td.get_file_name()
-            repo.create_submodule(
-                a_sm_name,
-                a_sm_path,
-                url=git_submodule.git_dir,
-                branch='master'
-            )
-            repo.index.commit(
-                f'Add submodule {a_sm_name} to {a_sm_path} from: {repo.git_dir}'
-            )
-
-            return (tmp_dir, repo)
-        return (tmp_dir, repo)
-
-    yield _git_repository
-    tmp_dir.delete()
-
-
-@pytest.fixture
-def simple_repo(mk_git_repo) -> RepoT:
-    yield mk_git_repo()
-
-
-@pytest.fixture
-def repo_with_submodule(mk_git_repo) -> RepoT:
-    base_dir, sub_repo = mk_git_repo()
-    _, main_repo = mk_git_repo(git_submodule=sub_repo)
-
-    yield (base_dir, main_repo)
-
-
 def describe_git():
 
     def submodule_versions_do_not_get_expanded():

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -258,3 +258,31 @@ def describe_git():
         expected_variants = [('1',), ('2',), ('3',)]
 
         assert variants == expected_variants
+
+    @mock.patch('benchbuild.source.git.base.target_prefix')
+    def repo_can_be_fetched(mocked_prefix, simple_repo):
+        base_dir, repo = simple_repo
+        mocked_prefix.return_value = str(base_dir)
+
+        a_repo = source.Git(remote=repo.git_dir, local='test.git')
+        cache_path = a_repo.fetch()
+
+        assert (base_dir / 'test.git').exists()
+        assert cache_path == str(base_dir / 'test.git')
+
+    @mock.patch('benchbuild.source.git.base.target_prefix')
+    def repo_clones_submodules(mocked_prefix, repo_with_submodule):
+        base_dir, repo = repo_with_submodule
+        mocked_prefix.return_value = str(base_dir)
+
+        a_repo = source.Git(remote=repo.git_dir, local='test.git')
+        a_repo.fetch()
+
+        for submodule in repo.submodules:
+            expected_sm_path = base_dir / 'test.git' / submodule.path
+            assert expected_sm_path.exists()
+            assert expected_sm_path.list() != []
+
+    @mock.patch('benchbuild.source.git.base.target_prefix')
+    def submodule_can_coexist_with_main(mocked_prefix, repo_with_submodule):
+        pass

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -320,14 +320,19 @@ def describe_git():
 
         for submodule in repo.submodules:
             expected_sub_path = base_dir / 'test.git' / submodule.path
+            expected_flat_sub_path = base_dir / f'test.git-{submodule.path}'
+
             sub_path = f'test.git/{submodule.path}'
             a_sub_repo = source.GitSubmodule(
                 remote=submodule.url, local=str(sub_path)
             )
-            a_sub_repo.fetch()
+            cache_patch = a_sub_repo.fetch()
 
             assert expected_sub_path.exists()
+            assert expected_flat_sub_path.exists()
             assert expected_sub_path.list() != []
+            assert expected_flat_sub_path.list() != []
+            assert cache_patch == expected_flat_sub_path
 
     @mock.patch('benchbuild.source.git.base.target_prefix')
     def repo_can_list_versions(mocked_prefix, simple_repo):


### PR DESCRIPTION
## Preface

This set of patches contains two change areas, because they are directly related.

1. Change ABC-based subtyping to structural subtyping using Protocols
    This reduces hard dependencies in other parts of benchbuild and enabled implicit subtyping for sources.

2. Implement GitSubmodules as 'virtual' sources. These do not take part in version expansion, but can be used like
    any other Git source in special applications.

This PR will close #306 

### Structural subtyping in Sources

This converts the interface <-> ABC relationship of ISource and BaseSource into
more pythonic structural subtyping.

We provide several protocols, which are identical to plain simple ABC's at
runtime:
 * Fetchable - Something that can be downloaded from a remote location
 * Expandable - Something that can decide whether it wants to take part in
                version expansion
     (e.g. a source that provides elements in a tuple of a cross-product)
 * Versions - Something that can select and enumerate versions.

By default, we provide a 'FetchableSource' that can be used as a base class that
supports all 3 protocols. Future commits, will make more fine-grain use of these
protocols. This is a quick-and-dirty 1:1 conversion from the previous state.

### Support for GitSubmodule

A GitSubmodule is treated just like any other FetchableSource in benchbuild. However, a GitSubmodule source
does not take part in version expansion (see source.product).

If you want to reason about the version history of a git submodule or even change the checked out version(!) during
an experiment run, you can use the usual methods: ``version``, ``fetch`` and ``versions``.

Example:

```{python}
SOURCE = [
    Git(remote='https://github.com/foo/bar', local='bar.git),
    GitSubmodule(remote='https://github.com/foo/baz', local='bar.git/baz.git')
]
```

If the Git source takes care of the submodule checkout, GitSubmodule should not require a clone (but it can, of course).

State:
- [x] Do not expand GitSubmodule versions
- [ ] Make sure that ``project.source_of``, ``project.version_of`` return reasonable information about Submodules.
      This requires some thought, because the assigned variant is used as the lookup index for the associated sources.
- [x] End-To-End tests with a git repository setup. Hard to mock ;-).