### PR TITLE
pygit2 1.4.0 requires libgit2-dev 1.1.0

### DIFF
--- a/benchbuild/environments/domain/declarative.py
+++ b/benchbuild/environments/domain/declarative.py
@@ -56,7 +56,7 @@ class ContainerImage(list):
 
 DEFAULT_BASES: tp.Dict[str, ContainerImage] = {
     'benchbuild:alpine': ContainerImage() \
-            .from_("alpine:latest") \
+            .from_("alpine:edge") \
             .run('apk', 'update') \
             .run('apk', 'add', 'python3', 'python3-dev', 'postgresql-dev',
                  'linux-headers', 'musl-dev', 'git', 'gcc', 'sqlite-libs',


### PR DESCRIPTION
libgit2-dev:1.1.0 is only available in alpine:edge. So, we bump the
version.