### PR TITLE
fix(x264): use local name of source for lookup

### DIFF
--- a/benchbuild/projects/benchbuild/x264.py
+++ b/benchbuild/projects/benchbuild/x264.py
@@ -52,7 +52,10 @@ class X264(bb.Project):
 
     def run_tests(self):
         x264_repo = local.path(self.source_of('x264.git'))
-        inputfiles = [self.source_of('tbbt-small'), self.source_of('sintel')]
+        inputfiles = [
+            self.source_of('tbbt-small.y4m'),
+            self.source_of('sintel.raw')
+        ]
 
         x264 = bb.wrap(x264_repo / "x264", self)
         tests = [


### PR DESCRIPTION
The lookup key for sources is the name of the local reference, not the key in the SOURCE dictionary.

Fixes #356