### PR TITLE
feat: add support for --export and --import flags in containers

### DIFF
--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -2,10 +2,11 @@ import logging
 import os
 import typing as tp
 
+from plumbum import local
 from plumbum.commands.base import BaseCommand
 
 from benchbuild.settings import CFG
-from benchbuild.utils.cmd import podman
+from benchbuild.utils.cmd import podman, rm
 
 LOG = logging.getLogger(__name__)
 
@@ -52,6 +53,16 @@ def create_container(
 
     LOG.debug('created container: %s', container_id)
     return container_id
+
+
+def save(image_id: str, out_path: str) -> None:
+    if local.path(out_path).exists():
+        rm(out_path)
+    bb_podman('save')('-o', out_path, image_id)
+
+
+def load(image_name: str, load_path: str) -> None:
+    bb_podman('load')('-i', load_path, image_name)
 
 
 def run_container(name: str) -> None:

--- a/benchbuild/environments/adapters/repository.py
+++ b/benchbuild/environments/adapters/repository.py
@@ -69,6 +69,18 @@ class AbstractRegistry(abc.ABC):
         raise NotImplementedError
 
 
+class ImageRegistry:
+
+    def create(self, tag: str, layers: tp.List[model.Layer]) -> model.Container:
+        from_ = [l for l in layers if isinstance(l, model.FromLayer)].pop(0)
+        image = model.Image(tag, from_, [])
+
+        container_id = buildah.create_working_container(image.from_)
+        context = buildah.create_build_context()
+
+        return model.Container(container_id, image, context)
+
+
 @attr.s
 class BuildahRegistry(AbstractRegistry):
 

--- a/benchbuild/environments/adapters/repository.py
+++ b/benchbuild/environments/adapters/repository.py
@@ -69,18 +69,6 @@ class AbstractRegistry(abc.ABC):
         raise NotImplementedError
 
 
-class ImageRegistry:
-
-    def create(self, tag: str, layers: tp.List[model.Layer]) -> model.Container:
-        from_ = [l for l in layers if isinstance(l, model.FromLayer)].pop(0)
-        image = model.Image(tag, from_, [])
-
-        container_id = buildah.create_working_container(image.from_)
-        context = buildah.create_build_context()
-
-        return model.Container(container_id, image, context)
-
-
 @attr.s
 class BuildahRegistry(AbstractRegistry):
 

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -1,6 +1,21 @@
+import re
+import unicodedata
+
 import attr
 
 from . import declarative
+
+
+def fs_compliant_name(name: str) -> str:
+    """
+    Convert a name to a valid filename.
+    """
+    value = str(name)
+    value = unicodedata.normalize('NFKD',
+                                  value).encode('ascii',
+                                                'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value.lower())
+    return re.sub(r'[-\s]+', '-', value).strip('-_')
 
 
 def oci_compliant_name(name: str) -> str:
@@ -68,6 +83,18 @@ class RunProjectContainer(Command):
     name: str = attr.ib(converter=oci_compliant_name)
 
     build_dir: str = attr.ib()
+
+
+@attr.s(frozen=True, hash=False)
+class ExportImage(Command):
+    image: str = attr.ib(converter=oci_compliant_name)
+    out_name: str = attr.ib()
+
+
+@attr.s(frozen=True, hash=False)
+class ImportImage(Command):
+    image: str = attr.ib(converter=oci_compliant_name)
+    in_path: str = attr.ib()
 
 
 # pylint: enable=too-few-public-methods

--- a/benchbuild/environments/service_layer/handlers.py
+++ b/benchbuild/environments/service_layer/handlers.py
@@ -88,3 +88,25 @@ def run_project_container(
 
         container = uow.create_container(cmd.image, cmd.name)
         uow.run_container(container)
+
+
+def export_image_handler(
+    cmd: commands.ExportImage, uow: unit_of_work.AbstractUnitOfWork
+) -> None:
+    """
+    Export a container image.
+    """
+    with uow:
+        ensure.image_exists(cmd.image, uow)
+        image = uow.registry.get_image(cmd.image)
+        uow.export_image(image.name, cmd.out_name)
+
+
+def import_image_handler(
+    cmd: commands.ImportImage, uow: unit_of_work.AbstractUnitOfWork
+) -> None:
+    """
+    Import a container image.
+    """
+    with uow:
+        uow.import_image(cmd.image, cmd.in_path)

--- a/benchbuild/environments/service_layer/handlers.py
+++ b/benchbuild/environments/service_layer/handlers.py
@@ -99,7 +99,8 @@ def export_image_handler(
     with uow:
         ensure.image_exists(cmd.image, uow)
         image = uow.registry.get_image(cmd.image)
-        uow.export_image(image.name, cmd.out_name)
+        if image:
+            uow.export_image(image.name, cmd.out_name)
 
 
 def import_image_handler(

--- a/benchbuild/environments/service_layer/messagebus.py
+++ b/benchbuild/environments/service_layer/messagebus.py
@@ -100,5 +100,7 @@ COMMAND_HANDLERS = {
     commands.CreateImage: handlers.create_image,
     commands.UpdateImage: handlers.update_image,
     commands.CreateBenchbuildBase: handlers.create_benchbuild_base,
-    commands.RunProjectContainer: handlers.run_project_container
+    commands.RunProjectContainer: handlers.run_project_container,
+    commands.ExportImage: handlers.export_image_handler,
+    commands.ImportImage: handlers.import_image_handler
 }

--- a/benchbuild/environments/service_layer/unit_of_work.py
+++ b/benchbuild/environments/service_layer/unit_of_work.py
@@ -32,6 +32,12 @@ class AbstractUnitOfWork(abc.ABC):
     ) -> model.Container:
         return self._create_container(image_id, container_name)
 
+    def export_image(self, image_id: str, out_path: str) -> None:
+        return self._export_image(image_id, out_path)
+
+    def import_image(self, image_name: str, import_path: str) -> None:
+        return self._import_image(image_name, import_path)
+
     def run_container(self, container: model.Container) -> None:
         podman.run_container(container.container_id)
 
@@ -61,6 +67,14 @@ class AbstractUnitOfWork(abc.ABC):
     ) -> model.Container:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def _export_image(self, image_id: str, out_path: str) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _import_image(self, image_name: str, import_path: str) -> None:
+        raise NotImplementedError
+
 
 class ContainerImagesUOW(AbstractUnitOfWork):
 
@@ -84,6 +98,12 @@ class ContainerImagesUOW(AbstractUnitOfWork):
         self, container: model.Container, layer: model.Layer
     ) -> None:
         buildah.spawn_layer(container, layer)
+
+    def _export_image(self, image_id: str, out_path: str) -> None:
+        podman.save(image_id, out_path)
+
+    def _import_image(self, image_name: str, import_path: str) -> None:
+        podman.load(image_name, import_path)
 
     def rollback(self) -> None:
         while self.registry.build_containers:

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -310,6 +310,18 @@ CFG["plugins"] = {
 }
 
 CFG["container"] = {
+    "export": {
+        "default":
+            s.ConfigPath(os.path.join(os.getcwd(), "containers", "export")),
+        "desc":
+            "Export path for container images."
+    },
+    "import": {
+        "default":
+            s.ConfigPath(os.path.join(os.getcwd(), "containers", "export")),
+        "desc":
+            "Import path for container images."
+    },
     "from_source": {
         "default": False,
         "desc": "Install benchbuild from source or from pip (default)"

--- a/docs/basics/containers.md
+++ b/docs/basics/containers.md
@@ -1,0 +1,60 @@
+Benchbuild allows the definition of container images to define the base system
+all experiment runs run in for a given project.
+
+## Usage
+
+If you want to run an experiment inside the project's container, simply replace
+the usual ``run`` subcommand with the ``container`` subcommand. Project and
+experiment selection are done in the same way.
+
+Example:
+```
+benchbuild container -E raw linpack
+```
+
+This will run the following stages:
+
+  1. Build all necessary base images.
+     All images are initiated from a base image. Benchbuild knows how to construct
+     a few base images. These will be prepared with all dependencies required to
+     run benchbuild inside the container.
+  2. Build all project images. Each project has to define its' own image.
+  3. Build the experiment images. Each experiment can add anything it needs to the
+     project images, if required. Use this to bring tools into the image that do
+     not require any knowledge about the environment to run properly.
+     For anything else, consider using a custom base image.
+
+## Definition
+
+A project that wants to use a container image needs to define it in the
+``CONTAINER`` attribute it using our declarative API provided by
+``benchbuild.environments.domain.declarative``.
+
+```
+from benchbuild.environments.domain.declarative import ContainerImage
+
+class Testproject(Project):
+  CONTAINER = ContainerImage().from_('benchbuild:alpine')
+```
+
+The available set of commands follows the structure of a ``Dockerfile``.
+
+## Runtime requirements
+
+For containers to work properly, you need a few systems set up beforehand.
+
+### Buildah
+
+Image construction requires the [Buildah](https://buildah.io) tool. All image
+construction tasks are formulated as buildah command calls in the backend.
+
+### Podman
+
+Container construction and execution is handed off to [Podman](https://podman.io).
+Podman provides rootless containers and does not requires the execution of a
+daemon process. However, you need to setup your user namespace properly to allow
+mapping of subordinate uids/gids. Otherwise, podman will not be able to map
+users other than the root user to filesystem permissions inside the container.
+
+Please refer to podman's documentation on how to setup podman properly on your
+system.

--- a/docs/basics/containers.md
+++ b/docs/basics/containers.md
@@ -24,6 +24,33 @@ This will run the following stages:
      not require any knowledge about the environment to run properly.
      For anything else, consider using a custom base image.
 
+## Configuration
+
+You can configure the container environment using the following config variables.
+
+- ``BB_CONTAINER_EXPORT``: Path where benchbuild stores exported container
+  images. By default we store it in ``./containers/export``. Will be created
+  automatically, if needed.
+- ``BB_CONTAINER_IMPORT``: Path where to input images from into the registry.
+  By default we load from ``./containers/export``.
+- ``BB_CONTAINER_FROM_SOURCE``: Determine, if we should use benchbuild from the
+  current source checkout, or from pip.
+- ``BB_CONTAINER_ROOT``: Where we store our image layers. This is the image
+  registry. Cannot be stored on filesystems that do not support subuid/-gid
+  mapping, e.g. NFS.
+  The default location is ``./containers/lib``.
+- ``BB_CONTAINER_RUNROOT``: Where we store temporary image layers of running
+  containers. See ``BB_CONTAINER_ROOT`` for restrictions.
+  The default location is: ``./containers/run``.
+- ``BB_CONTAINER_RUNTIME``: Podman can use any standard OCI-container runtime to
+  launch containers. We use [crun](https://github.com/containers/crun) by
+  default. Depending on your system, this one has already been installed with
+  ``podman``.
+  The default runtime is: ``/usr/bin/crun``
+- ``BB_CONTAINER_MOUNTS``: A list of mountpoint definitions that should be added
+  to all containers. With this you can add arbitrary tools into all containers.
+  Default: ``[]``
+
 ## Definition
 
 A project that wants to use a container image needs to define it in the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Getting Started:
       - basics/index.md
       - basics/configuration.md
+      - basics/containers.md
   - Concepts:
       - concepts/source.md
       - concepts/environments.md


### PR DESCRIPTION
This adds support for two new flags when dealing with benchbuild
containers.

  * --export: Exports the generated base image layers as .tar archive to
    the filesystem.
    An existing export will be overwritten. This does not change the
    registry.
  * --import: Imports the image from a .tar archive into the registry.
    Existing layers in the registry will be checked for a necessary
    import.

The import/export locations can be controlled by two new configuration
settings:
  * BB_CONTAINER_EXPORT: ConfigPath, default: <cwd>/containers/export
  * BB_CONTAINER_IMPORT: ConfigPath, default: <cwd>/containers/export

Benchbuild controls the filename. We will use a 'slugified' version of
the image tag as filename, e.g., benchbuild/alpine:latest becomes
benchbuildalpinelatest.tar