### PR TITLE
feat(environments): add option to replace container images

### DIFF
--- a/benchbuild/environments/entrypoints/cli.py
+++ b/benchbuild/environments/entrypoints/cli.py
@@ -38,6 +38,12 @@ class BenchBuildContainer(cli.Application):  # type: ignore
                             default=False,
                             help="Import container images from EXPORT_DIR")
 
+    @cli.switch(['--replace'],
+                requires=['--experiment'],
+                help='Replace existing container images.')
+    def set_replace(self) -> None:
+        CFG['container']['replace'] = True
+
     def main(self, *projects: str) -> int:
         plugins.discover()
 

--- a/benchbuild/environments/entrypoints/cli.py
+++ b/benchbuild/environments/entrypoints/cli.py
@@ -38,14 +38,16 @@ class BenchBuildContainer(cli.Application):  # type: ignore
                             default=False,
                             help="Import container images from EXPORT_DIR")
 
-    @cli.switch(['--replace'],
-                requires=['--experiment'],
-                help='Replace existing container images.')
-    def set_replace(self) -> None:
-        CFG['container']['replace'] = True
+    replace = cli.Flag(['replace'],
+                       default=False,
+                       requires=['experiment'],
+                       help='Replace existing container images.')
 
     def main(self, *projects: str) -> int:
         plugins.discover()
+
+        if self.replace:
+            CFG['container']['replace'] = True
 
         cli_experiments = self.experiment_args
         cli_groups = self.group_args

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -310,6 +310,10 @@ CFG["plugins"] = {
 }
 
 CFG["container"] = {
+    "replace": {
+        "default": False,
+        "desc": "Replace existing container images."
+    },
     "export": {
         "default":
             s.ConfigPath(os.path.join(os.getcwd(), "containers", "export")),

--- a/docs/basics/containers.md
+++ b/docs/basics/containers.md
@@ -24,6 +24,20 @@ This will run the following stages:
      not require any knowledge about the environment to run properly.
      For anything else, consider using a custom base image.
 
+### Replace Images
+
+Benchbuild will reuse any existing images it can find in your image registry.
+The only relevant information is the image tag, e.g., ``benchbuild:alpine``.
+If you want to avoid reuse and force to rebuild images unconditionally, you can
+use the ``--replace`` flag when running the ``containers`` subcommand.
+
+Example:
+```
+benchbuild container --replace -E raw linpack
+```
+
+This will ignore **any** required image for the given experiments and projects.
+
 ## Configuration
 
 You can configure the container environment using the following config variables.


### PR DESCRIPTION
This adds a ``--replace`` flag that forces benchbuild to ignore
any existing image in the container image registry. All images
will be rebuilt.

Fixes #372