### PR TITLE
format project view differently

### DIFF
--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -93,21 +93,23 @@ def print_projects(projects: ProjectIndex) -> None:
     project_column_width = max([
         len(f'{p.NAME}/{p.GROUP}') for p in projects.values()
     ])
-    project_header_format = "{:<{width}} | {:^15} | {:^15} | {}"
-    project_row_format = "{:<{width}} | {:^15} | {:^15} | {}"
+    project_header_format = (
+        "{name_header:<{width}} | {source_header:^15} | "
+        "{version_header:^15} | {description_header}"
+    )
+    project_row_format = "{name:<{width}} | {num_sources:^15} | {num_combinations:^15} | {description}"
 
     for name in grouped_by:
         group_projects = sorted(grouped_by[name])
         print(
             project_header_format.format(
-                f'{name}',
-                "# Sources",
-                "# Versions",
-                "Description",
+                name_header=f'{name}',
+                source_header="# Sources",
+                version_header="# Versions",
+                description_header="Description",
                 width=project_column_width
             )
         )
-        print()
         for prj_name in group_projects:
             prj_cls = projects[prj_name]
             project_id = f'{prj_cls.NAME}/{prj_cls.GROUP}'
@@ -121,10 +123,10 @@ def print_projects(projects: ProjectIndex) -> None:
                 docstr = prj_cls.__doc__.strip("\n ")
             print(
                 project_row_format.format(
-                    project_id,
-                    num_project_sources,
-                    num_combinations,
-                    docstr,
+                    name=project_id,
+                    num_sources=num_project_sources,
+                    num_combinations=num_combinations,
+                    description=docstr,
                     width=project_column_width
                 )
             )

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -7,6 +7,7 @@ from plumbum import cli
 import benchbuild as bb
 from benchbuild.environments.domain.declarative import ContainerImage
 from benchbuild.project import ProjectIndex, Project
+from benchbuild.settings import CFG
 
 
 class BBProject(cli.Application):
@@ -51,13 +52,21 @@ class BBProjectDetails(cli.Application):
 
 
 def print_project(project: tp.Type[Project]) -> None:
+    tmp_dir = CFG['tmp_dir']
+
     print(f'project: {project.NAME}')
+    print(f'group: {project.GROUP}')
+    print(f'domain: {project.DOMAIN}')
     print('source:')
     for source in project.SOURCE:
-        print(' ', f'{source.remote}')
-        print('versions')
-        for v in source.versions():
-            print(' ', v)
+        num_versions = len(source.versions())
+
+        print(' -', f'{source.remote}')
+        print('  ', 'default:', source.default)
+        print('  ', f'versions: {num_versions}')
+        print('  ', 'local:', f'{tmp_dir}/{source.local}')
+        for v in list(source.versions()):
+            print('  ' * 2, v)
     containers = []
     if isinstance(project.CONTAINER, ContainerImage):
         containers.append(project.CONTAINER)

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -45,8 +45,8 @@ class BBProjectDetails(cli.Application):
             print(f'Project named {project} not found in the registry.')
             print('Maybe it is not configured to be loaded.')
             return -1
-        for project in index.values():
-            print_project(project)
+        for project_cls in index.values():
+            print_project(project_cls)
         return 0
 
 
@@ -114,7 +114,7 @@ def print_projects(projects: ProjectIndex) -> None:
             num_project_sources = len(prj_cls.SOURCE)
             num_combinations = reduce(
                 lambda x, y: x * y,
-                [len(src.versions()) for src in prj_cls.SOURCE]
+                [len(list(src.versions())) for src in prj_cls.SOURCE]
             )
             docstr = ""
             if prj_cls.__doc__:

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -40,6 +40,14 @@ class BBProjectView(cli.Application):
 class BBProjectDetails(cli.Application):
     """Show details for a project."""
 
+    limit: int = 10
+
+    @cli.switch(["-l", "--limit"],
+                int,
+                help="Limit the number of versions to display")
+    def set_limit(self, limit):
+        self.limit = limit
+
     def main(self, project: str) -> int:
         index = bb.populate([project], [])
         if not index.values():
@@ -47,11 +55,11 @@ class BBProjectDetails(cli.Application):
             print('Maybe it is not configured to be loaded.')
             return -1
         for project_cls in index.values():
-            print_project(project_cls)
+            print_project(project_cls, self.limit)
         return 0
 
 
-def print_project(project: tp.Type[Project]) -> None:
+def print_project(project: tp.Type[Project], limit: int) -> None:
     tmp_dir = CFG['tmp_dir']
 
     print(f'project: {project.NAME}')
@@ -65,7 +73,7 @@ def print_project(project: tp.Type[Project]) -> None:
         print('  ', 'default:', source.default)
         print('  ', f'versions: {num_versions}')
         print('  ', 'local:', f'{tmp_dir}/{source.local}')
-        for v in list(source.versions()):
+        for v in list(source.versions())[:limit]:
             print('  ' * 2, v)
     containers = []
     if isinstance(project.CONTAINER, ContainerImage):

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -45,7 +45,7 @@ class BBProjectDetails(cli.Application):
     @cli.switch(["-l", "--limit"],
                 int,
                 help="Limit the number of versions to display")
-    def set_limit(self, limit):
+    def set_limit(self, limit: int) -> None:
         self.limit = limit
 
     def main(self, project: str) -> int:

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -90,7 +90,7 @@ def print_project(project: tp.Type[Project], limit: int) -> None:
 
     print('container:')
     for container in containers:
-        print(' ', container)
+        print(' ', str(container))
 
 
 def print_projects(projects: ProjectIndex) -> None:

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -60,6 +60,13 @@ class BBProjectDetails(cli.Application):
 
 
 def print_project(project: tp.Type[Project], limit: int) -> None:
+    """
+    Print details for a single project.
+
+    Args:
+        project: The project to print.
+        limit: The maximal number of versions to print.
+    """
     tmp_dir = CFG['tmp_dir']
 
     print(f'project: {project.NAME}')

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -1,5 +1,6 @@
 """Subcommand for project handling."""
 import typing as tp
+from functools import reduce
 
 from plumbum import cli
 
@@ -41,14 +42,12 @@ def print_projects(projects: ProjectIndex) -> None:
         projects: The populated project index to print.
 
     """
-    grouped_by: tp.Dict[str, tp.List[str]] = {}
     if not projects:
         print("Your selection didn't include any projects for this experiment.")
         return
 
-    for name in projects:
-        prj = projects[name]
-
+    grouped_by: tp.Dict[str, tp.List[str]] = {}
+    for prj in set(projects.values()):
         if prj.GROUP not in grouped_by:
             grouped_by[prj.GROUP] = []
 
@@ -56,39 +55,42 @@ def print_projects(projects: ProjectIndex) -> None:
             "{name}/{group}".format(name=prj.NAME, group=prj.GROUP)
         )
 
+    project_column_width = max([
+        len(f'{p.NAME}/{p.GROUP}') for p in projects.values()
+    ])
+    project_header_format = "{:<{width}} | {:^15} | {:^15} | {}"
+    project_row_format = "{:<{width}} | {:^15} | {:^15} | {}"
+
     for name in grouped_by:
-        print(f'::  group: {name}')
         group_projects = sorted(grouped_by[name])
+        print(
+            project_header_format.format(
+                f'{name}',
+                "# Sources",
+                "# Versions",
+                "Description",
+                width=project_column_width
+            )
+        )
+        print()
         for prj_name in group_projects:
             prj_cls = projects[prj_name]
-
             project_id = f'{prj_cls.NAME}/{prj_cls.GROUP}'
-            project_version = str(bb.source.default(*prj_cls.SOURCE))
-
-            project_lines = [
-                f'::  {project_id}'
-                f'    default: {project_version:<24}'
-            ]
-            for src in prj_cls.SOURCE:
-                source_lines = [
-                    f'\n    * source: {src.local}',
-                ]
-                if isinstance(src.remote, str):
-                    source_lines.append(f' remote: {src.remote}')
-                    source_lines.extend([
-                        f'\n      - {str(version)}'
-                        for version in src.versions()
-                    ])
-                else:
-                    source_lines.extend([
-                        f'\n      - {str(version)} '
-                        f'remote: {src.remote[str(version)]}'
-                        for version in src.versions()
-                    ])
-                project_lines.extend(source_lines)
-
-            print(*project_lines)
+            num_project_sources = len(prj_cls.SOURCE)
+            num_combinations = reduce(
+                lambda x, y: x * y,
+                [len(src.versions()) for src in prj_cls.SOURCE]
+            )
+            docstr = ""
             if prj_cls.__doc__:
                 docstr = prj_cls.__doc__.strip("\n ")
-                print(f'    description: {docstr}')
+            print(
+                project_row_format.format(
+                    project_id,
+                    num_project_sources,
+                    num_combinations,
+                    docstr,
+                    width=project_column_width
+                )
+            )
         print()

--- a/benchbuild/cli/project.py
+++ b/benchbuild/cli/project.py
@@ -97,7 +97,10 @@ def print_projects(projects: ProjectIndex) -> None:
         "{name_header:<{width}} | {source_header:^15} | "
         "{version_header:^15} | {description_header}"
     )
-    project_row_format = "{name:<{width}} | {num_sources:^15} | {num_combinations:^15} | {description}"
+    project_row_format = (
+        "{name:<{width}} | {num_sources:^15} | "
+        "{num_combinations:^15} | {description}"
+    )
 
     for name in grouped_by:
         group_projects = sorted(grouped_by[name])

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -54,7 +54,7 @@ class ProjectRegistry(type):
     projects = StringTrie()
 
     def __new__(
-        mcs: tp.Type[tp.Any], name: str, bases: tp.Tuple[type, ...],
+        mcs: tp.Type['Project'], name: str, bases: tp.Tuple[type, ...],
         attrs: tp.Dict[str, tp.Any]
     ) -> tp.Any:
         """Register a project in the registry."""

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -59,17 +59,18 @@ class ProjectRegistry(type):
     ) -> tp.Any:
         """Register a project in the registry."""
         cls = super(ProjectRegistry, mcs).__new__(mcs, name, bases, attrs)
+        name = attrs["NAME"] if "NAME" in attrs else cls.NAME
+        domain = attrs["DOMAIN"] if "DOMAIN" in attrs else cls.DOMAIN
+        group = attrs["GROUP"] if "GROUP" in attrs else cls.GROUP
 
-        defined_attrs = all(
-            attr in attrs and attrs[attr] is not None
-            for attr in ['NAME', 'DOMAIN', 'GROUP']
-        )
+        defined_attrs = all(bool(attr) for attr in [name, domain, group])
 
         if bases and defined_attrs:
-            key = f'{attrs["NAME"]}/{attrs["GROUP"]}'
-            key_dash = f'{attrs["NAME"]}-{attrs["GROUP"]}'
+            key = f'{name}/{group}'
+            key_dash = f'{name}-{group}'
             ProjectRegistry.projects[key] = cls
             ProjectRegistry.projects[key_dash] = cls
+
         return cls
 
 


### PR DESCRIPTION
This PR changes the output format of ``project view``'. We only include high-level information about the existing projects, such as:

* name/group. For discovery of provided projects
* the number of sources. so you get an idea how many different sources you might need to download.
* the number of "variants" we can generate from the sources.

If a user wants details about a single projects, e.g., the versions available to this project, there is a new subcommand ``project details`` that provides this information.

The output format is up for improvement.