### PR TITLE
feat(utils/slurm): add customizable SLURM templates

### DIFF
--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -190,6 +190,10 @@ CFG["slurm"] = {
         "desc": "The SLURM partition to use by default.",
         "default": "chimaira"
     },
+    "template": {
+        "desc": "Template used to generate a SLURM script.",
+        "default": "misc/slurm.sh.inc"
+    },
     "script": {
         "desc":
             "Name of the script that can be passed to SLURM. Used by external "

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -1,1 +1,28 @@
-# TODO
+# SLURM
+
+BenchBuild supports a high-level integration with the SLURM cluster resource
+manager. An experiment setup can be exported as a SLURM bash script. Assuming
+you have access to a configured benchbuid environment on the SLURM cluster, you
+can provide the SLURM script to the ``sbatch`` command and have your experiment
+run on the cluster environment.
+
+## Basics
+
+TODO
+
+## Template customization
+
+This customization is not recommended for the default use-case. However, you
+might run in a situation where the existing cluster-environment requires a
+more complicated setup than BenchBuild can provide.
+
+You can customize the template that is used for the SLURM script using a
+modified copy of the base template BenchBuild uses
+(see ``benchbuild/res/misc/slurm.sh.inc``).
+
+The customized template can be configured using the configuration option
+``BB_SLURM_TEMPLATE``. If BenchBuild detects that the provided value points to
+an existing file in your filesystem, it will load it.
+If you change the setting and BenchBuild cannot find a file there, no script
+will be generated. No validation of the template will be done, use at your own
+risk.


### PR DESCRIPTION
This adds (basic) support for customizable SLURM templates.
Only use this, if you know what you are doing. You can copy an example
template from ``benchbuild/res/misc/slurm.sh.inc``.

All Jinja2 variables used in this template will be filled with values by
``utils/slurm`` during script generation. Benchbuild does not really
rely on anything inside the script, if you can make the environment work
in some other way.

A new configuration setting can be used to supply a new template. This
is not a front-facing feature for the end-user.
``'BB_SLURM_TEMPLATE`` controls the template that is used. By default, we
use ``res/misc/slurm.sh.inc`` using Jinja2's ``PackageLoader``. If
benchbuild detects an existing file in your filesystem on the given path
value, it will use a ``FileSystemLoader`` instead.