### PR TITLE
feat(environments): add an interactive mode for container runs.

### DIFF
--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -217,6 +217,29 @@ def store_failed_build(tag: str,
     return failed_tag, err
 
 
+def find_entrypoint(tag: str) -> str:
+    """
+    Find and return the entrypoint of a container image.
+
+    This assumes an image tag configured by benchbuild as input.
+
+    Args:
+        tag: the image tage.
+
+    Returns:
+        A tuple of the configured entrypoint joined with whitespace and the
+        command's error state.
+    """
+    inspect_str = bb_buildah('inspect')(tag)
+    json_output = json.loads(inspect_str)
+
+    config = json_output['OCIv1']['config']
+    if not config:
+        raise ValueError("Could not find the container image config")
+
+    return ' '.join(config['Entrypoint'])
+
+
 class ImageRegistry(abc.ABC):
     images: tp.Dict[str, model.Image]
     containers: tp.Dict[str, model.Container]

--- a/benchbuild/environments/adapters/common.py
+++ b/benchbuild/environments/adapters/common.py
@@ -77,10 +77,20 @@ def run(cmd: BaseCommand, **kwargs: tp.Any) -> tp.Tuple[str, MaybeCommandError]:
 
 
 def run_tee(cmd: BaseCommand,
-            **kwargs: tp.Any) -> tp.Tuple[str, MaybeCommandError]:
+            **kwargs: tp.Any) -> tp.Tuple[tp.Any, MaybeCommandError]:
     result = ""
     try:
         result = cmd.run_tee(**kwargs)
+    except ProcessExecutionError as err:
+        return result, err
+    return result, None
+
+
+def run_fg(cmd: BaseCommand,
+           **kwargs: tp.Any) -> tp.Tuple[tp.Any, MaybeCommandError]:
+    result = ""
+    try:
+        result = cmd.run_fg(**kwargs)
     except ProcessExecutionError as err:
         return result, err
     return result, None

--- a/benchbuild/environments/entrypoints/cli.py
+++ b/benchbuild/environments/entrypoints/cli.py
@@ -68,11 +68,17 @@ class BenchBuildContainerRun(cli.Application):  # type: ignore
                      requires=['experiment'],
                      help='Debug failed image builds interactively.')
 
+    interactive = cli.Flag(['interactive'],
+                           default=False,
+                           requires=['experiment', 'debug'],
+                           help='Run a container interactively.')
+
     def main(self, *projects: str) -> int:
         plugins.discover()
 
         CFG['container']['replace'] = self.replace
         CFG['container']['keep'] = self.debug
+        CFG['container']['interactive'] = self.interactive
 
         cli_experiments = self.experiment_args
         cli_groups = self.group_args

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -314,6 +314,10 @@ CFG["plugins"] = {
 }
 
 CFG["container"] = {
+    "interactive": {
+        "default": False,
+        "desc": "Drop into an interactive shell for all container runs"
+    },
     "keep": {
         "default": False,
         "desc": "Keep failed image builds at their last known good state."


### PR DESCRIPTION
This commits adds an interactive mode for all benchbuild container runs.

You can run any benchbuild container in an interactive shell session using
the ``--interactive --debug`` flags for ``container run``

Example:

benchbuild container run --debug --interactive -E raw bzip2

You will get a plain simple ``/bin/sh`` session inside the container.
The original container entrypoint will be printed as an introduction, so you can
start your debug session in the same environment as benchbuild would run your
experiment.