### PR TITLE
fix(settings): BB_ENV is ignored when no config file is loaded"

### DIFF
--- a/benchbuild/utils/settings.py
+++ b/benchbuild/utils/settings.py
@@ -201,7 +201,10 @@ InnerNode = tp.Dict[str, tp.Any]
 #  CFG['container']['strategy']['polyjit'] = {
 #    'sync': { 'default': True', 'desc': '...' }
 #  }
-_INNER_NODE_VALUE = schema.Schema({schema.Or('default', 'value'): object})
+_INNER_NODE_VALUE = schema.Schema({
+    schema.Or('default', 'value'): object,
+    schema.Optional('desc'): str
+})
 _INNER_NODE_SCHEMA = schema.Schema({
     schema.And(str, len): {
         schema.Or('default', 'value'): object,

--- a/tests/settings/test_configuration.py
+++ b/tests/settings/test_configuration.py
@@ -2,12 +2,38 @@ import uuid
 
 import pytest
 
-from benchbuild.utils.settings import Configuration
+from benchbuild.utils.settings import (
+    Configuration,
+    _INNER_NODE_SCHEMA,
+    _INNER_NODE_VALUE,
+)
 
 
 @pytest.fixture
 def bb():
     yield Configuration('bb')
+
+
+def describe_inner_nodes():
+
+    def dict_can_be_inner_node():
+        assert _INNER_NODE_VALUE.is_valid({'default': 0, 'desc': 'a'})
+
+    def dict_can_be_nested_once():
+        assert _INNER_NODE_SCHEMA.is_valid({'a': {'default': 0, 'desc': 'a'}})
+
+    def inner_node_value_can_be_assigned(bb):
+        bb['a'] = {'default': 0, 'desc': 'a'}
+        assert _INNER_NODE_SCHEMA.is_valid(bb.node)
+
+    def inner_node_needs_to_be_initialized():
+        cfg = Configuration('fresh')
+        cfg['a'] = {'default': 0, 'desc': 'a'}
+
+        assert not hasattr(cfg['a'].node, 'value')
+
+        cfg.init_from_env()
+        assert hasattr(cfg['a'], 'value')
 
 
 def test_simple_construction(bb):


### PR DESCRIPTION
The ``_INNER_NODE_VALUE`` schema did not cover inner nodes that define
a description as well.

In our default settings, BB_ENV is defined as such an inner node.
This creates a ``value`` entry at BB_ENV that is then fillen with the
dictionary from our default config.

This makes it impossible to fill the key ``BB_ENV`` from the
environment, as we now captured BB_ENV_VALUE as new leaf value.

This fixes #413