### PR TITLE
Extend target_prefix() to include benchbuild's `config_file` config option if set.

### DIFF
--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -243,14 +243,19 @@ def nosource() -> NoSource:
     return NoSource('NoSource', 'NoSource')
 
 
-def target_prefix() -> str:
+def target_prefix() -> pb.LocalPath:
     """
     Return the prefix directory for all downloads.
 
     Returns:
         str: the prefix where we download everything to.
     """
-    return str(CFG['tmp_dir'])
+    prefix = pb.local.path(".")
+    bb_root = str(CFG['config_file'])
+    if bb_root:
+        prefix = pb.local.path(bb_root)
+
+    return prefix / str(CFG['tmp_dir'])
 
 
 def default(*sources: Versioned) -> VariantContext:

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -62,7 +62,7 @@ class Git(base.FetchableSource):
             git['clone', '--recurse-submodules'], self.shallow
         )
         flat_local = self.local.replace(os.sep, '-')
-        cache_path = pb.local.path(prefix) / flat_local
+        cache_path = prefix / flat_local
 
         if clone_needed(self.remote, cache_path):
             clone(self.remote, cache_path)

--- a/benchbuild/source/http.py
+++ b/benchbuild/source/http.py
@@ -27,7 +27,7 @@ class HTTP(base.FetchableSource):
 
         url = remotes[version]
         target_name = versioned_target_name(self.local, version)
-        cache_path = pb.local.path(prefix) / target_name
+        cache_path = prefix / target_name
         download_single_version(url, cache_path)
 
         # FIXME: Belongs to environment code.

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -200,7 +200,7 @@ def describe_git():
     @mock.patch('benchbuild.source.git.base.target_prefix')
     def repo_can_be_fetched(mocked_prefix, simple_repo):
         base_dir, repo = simple_repo
-        mocked_prefix.return_value = str(base_dir)
+        mocked_prefix.return_value = pb.local.path(base_dir)
 
         a_repo = source.Git(remote=repo.git_dir, local='test.git')
         cache_path = a_repo.fetch()
@@ -211,7 +211,7 @@ def describe_git():
     @mock.patch('benchbuild.source.git.base.target_prefix')
     def repo_clones_submodules(mocked_prefix, repo_with_submodule):
         base_dir, repo = repo_with_submodule
-        mocked_prefix.return_value = str(base_dir)
+        mocked_prefix.return_value = pb.local.path(base_dir)
 
         a_repo = source.Git(remote=repo.git_dir, local='test.git')
         a_repo.fetch()
@@ -226,7 +226,7 @@ def describe_git():
         mocked_prefix, repo_with_submodule
     ):
         base_dir, repo = repo_with_submodule
-        mocked_prefix.return_value = str(base_dir)
+        mocked_prefix.return_value = pb.local.path(base_dir)
 
         a_repo = source.Git(remote=repo.git_dir, local='test.git')
         a_repo.fetch()
@@ -251,7 +251,7 @@ def describe_git():
         mocked_prefix, repo_with_submodule
     ):
         base_dir, repo = repo_with_submodule
-        mocked_prefix.return_value = str(base_dir)
+        mocked_prefix.return_value = pb.local.path(base_dir)
 
         a_repo = source.Git(remote=repo.git_dir, local='test.git')
         a_repo.fetch()
@@ -275,7 +275,7 @@ def describe_git():
     @mock.patch('benchbuild.source.git.base.target_prefix')
     def repo_can_list_versions(mocked_prefix, simple_repo):
         base_dir, repo = simple_repo
-        mocked_prefix.return_value = str(base_dir)
+        mocked_prefix.return_value = pb.local.path(base_dir)
         master = repo.head.reference
 
         a_repo = source.Git(remote=repo.git_dir, local='test.git')


### PR DESCRIPTION
This avoids having multiple `tmp` directories when calling benchbuild code from different directories (e.g., during tests or when using benchbuild as a library)