### PR TITLE
Treat integer and strings as scalar versions

### DIFF
--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -466,9 +466,10 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
         return False
 
     is_csv = csv(version_in)
+    is_scalar = isinstance(version_in, (str, int))
 
-    if isinstance(version_in, str) and not is_csv:
-        return __add_single_filter__(project, version_in)
+    if not is_csv and is_scalar:
+        return __add_single_filter__(project, str(version_in))
 
     if isinstance(version_in, list) or is_csv:
         version_in = version_in.split(',') if is_csv else version_in

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -166,9 +166,7 @@ def describe_project():
 def describe_filters():
 
     def is_generated_by_add_filters(project, filter_test):  # pylint: disable=unused-variable
-        filtered_prj = __add_filters__(
-            project, yaml.safe_dump(filter_test.t_input)
-        )
+        filtered_prj = __add_filters__(project, str(filter_test.t_input))
         assert isinstance(primary(*filtered_prj.SOURCE), SingleVersionFilter)
 
     def wraps_primary(project, filter_test):  # pylint: disable=unused-variable


### PR DESCRIPTION
When benchbuild adds version filters to projects, it processes the user-input using ``yaml.safe_load``.
This causes a version string of '1234' to be parsed as an integer, which fails all existing type-checks and
produces the ``ValueError`` reported in #421.

This fixes #421.
