### PR TITLE
Fix a bug for state resetting after test execution

### DIFF
--- a/tests/integration/test_cli_slurm.py
+++ b/tests/integration/test_cli_slurm.py
@@ -14,7 +14,7 @@ def cmd_mock() -> tp.Callable[[str], None]:
         cmd.__overrides__[name] = ['/bin/true']
 
     yield _cmd_mock
-    cmd.__overrides__ = []
+    cmd.__overrides__ = {}
 
 
 def test_slurm_command(tmp_path, cmd_mock):


### PR DESCRIPTION
This PR aims to fix a bug for state resetting after running the test `test_slurm_command`.

The original code is the following:
```
def _cmd_mock(name: str):
        cmd.__overrides__[name] = ['/bin/true']

    yield _cmd_mock
    cmd.__overrides__ = []
```
We can infer that `cmd.__overrides__` is a `dict`. So we should use `{}` instead of `[]` for state cleaning.

The bug can be triggered by running the test twice, e.g., `pip3 install pytest-repeat; python3 -m pytest tests/integration/test_cli_slurm.py::test_slurm_command --count=2`, and it fails like this:
```
    def test_slurm_command(tmp_path, cmd_mock):
>       cmd_mock('srun')

tests/integration/test_cli_slurm.py:21:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'srun'

    def _cmd_mock(name: str):
>       cmd.__overrides__[name] = ['/bin/true']
E       TypeError: list indices must be integers or slices, not str

tests/integration/test_cli_slurm.py:14: TypeError
```

The proposed patch can fix this issue.