### PR TITLE
Ensure a projects domain is converted before storing it

### DIFF
--- a/benchbuild/utils/db.py
+++ b/benchbuild/utils/db.py
@@ -96,7 +96,7 @@ def persist_project(project):
 
     name = project.name
     desc = project.__doc__
-    domain = project.domain
+    domain = str(project.domain)
     group_name = project.group
     version = str(project.variant)
     try:


### PR DESCRIPTION
Ensure that a projects domain is converted to a string before storing it
to the database. This is useful for projects that define their domain as
a `string convertible` object.