### PR TITLE
feat(source): update git remote revisions.

### DIFF
--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -61,11 +61,16 @@ class Git(base.FetchableSource):
         clone = maybe_shallow(
             git['clone', '--recurse-submodules'], self.shallow
         )
+        fetch = git['fetch', '--update-shallow', '--all']
         flat_local = self.local.replace(os.sep, '-')
         cache_path = pb.local.path(prefix) / flat_local
 
         if clone_needed(self.remote, cache_path):
             clone(self.remote, cache_path)
+        else:
+            with pb.local.cwd(cache_path):
+                fetch()
+
         return cache_path
 
     def version(self, target_dir: str, version: str = 'HEAD') -> pb.LocalPath:


### PR DESCRIPTION
This commit refreshes all available remote revisions of a cloned git
repository when running ``fetch()`` automatically.

The working directory inside tmp is *not* changed and behavior of
benchbuild will not change. A cloned repo inside benchbuild's tmp will
not update HEAD automatically.

A project has to change the refspec that is used for listing available
revisions.

Old, no auto-update:
```{python}
Git(remote='https://code.videolan.org/videolan/x264.git',
    local='x264.git',
    refspec='HEAD',
    limit=5
)
```

New, auto-update:
```{python}
Git(remote='https://code.videolan.org/videolan/x264.git',
    local='x264.git',
    refspec='origin/HEAD',
    limit=5
)
```

Existing project's that wish to make use of auto-update, have to update
their refspec property.