### PR TITLE
feat(utils/run): add unbuffered watch commands

### DIFF
--- a/benchbuild/cli/main.py
+++ b/benchbuild/cli/main.py
@@ -16,6 +16,10 @@ class BenchBuild(cli.Application):
     verbosity = cli.CountOf('-v', help="Enable verbose output")
     debug = cli.Flag('-d', help="Enable debugging output")
     force_tty = cli.Flag('--force-tty', help="Assume an available tty")
+    force_watch_unbuffered = cli.Flag(
+        '--force-watch-unbuffered',
+        help="Force watched commands to output unbuffered"
+    )
 
     def main(self, *args: str) -> int:
         cfg = settings.CFG
@@ -28,6 +32,7 @@ class BenchBuild(cli.Application):
         cfg["verbosity"] = verbosity
         cfg["debug"] = self.debug
         cfg["force_tty"] = self.force_tty
+        cfg["force_watch_unbuffered"] = self.force_watch_unbuffered
 
         log.configure()
         log.set_defaults()

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -45,6 +45,10 @@ CFG = s.Configuration(
             "desc": "Assume an active TTY.",
             "default": False
         },
+        "force_watch_unbuffered": {
+            "desc": "Force watched commands to output unbuffered.",
+            "default": False
+        },
         "jobs": {
             "desc": "Number of jobs that can be used for building and running.",
             "default": str(s.available_cpu_count())

--- a/benchbuild/utils/run.py
+++ b/benchbuild/utils/run.py
@@ -66,8 +66,8 @@ class RunInfo:
             (run, session), where run is the generated run instance and
             session the associated transaction for later use.
         """
-        from benchbuild.utils.db import create_run
         from benchbuild.utils import schema as s
+        from benchbuild.utils.db import create_run
 
         db_run, session = create_run(command, project, experiment, group)
         db_run.begin = datetime.datetime.now()
@@ -325,8 +325,10 @@ def watch(command: BaseCommand) -> WatchableCommand:
 
     def f(*args: t.Any, retcode: int = 0, **kwargs: t.Any) -> CommandResult:
         final_command = command[args]
+        buffered = not bool(CFG['force_watch_unbuffered'])
         return t.cast(
-            CommandResult, final_command.run_tee(retcode=retcode, **kwargs)
+            CommandResult,
+            final_command.run_tee(retcode=retcode, buffered=buffered, **kwargs)
         )
 
     return f

--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -1,0 +1,4 @@
+## CLI
+
+* ``--force-watch-unbuffered``: This disables buffering from watched commands.
+  This can help with tools that call benchbuild and use their own output buffering.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - concepts/experiments.md
   - Advanced Usage:
       - advanced/index.md
+      - advanced/cli.md
   #- API: mkapi/api/benchbuild
   - About:
     - Release Notes: CHANGELOG.md


### PR DESCRIPTION
The new CLI Switch ``--force-watch-unbuffered`` disables output buffering for watched commands.
We keep using buffered output by default.