### PR TITLE
feat(experiment): use __init_subclass__ instead of __new__

### DIFF
--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -28,7 +28,6 @@ import collections
 import copy
 import typing as tp
 import uuid
-import warnings
 from abc import abstractmethod
 
 import attr

--- a/benchbuild/experiment.py
+++ b/benchbuild/experiment.py
@@ -46,7 +46,7 @@ ProjectT = tp.Type[Project]
 Projects = tp.List[ProjectT]
 
 
-class NamedEntity:
+class NamedEntity:  # pylint: disable=too-few-public-methods
 
     @classmethod
     def __init_subclass__(cls, *args: tp.Any, entity_name: str, **kwargs):

--- a/benchbuild/experiments/empty.py
+++ b/benchbuild/experiments/empty.py
@@ -10,26 +10,24 @@ from benchbuild.extensions import compiler, run
 from benchbuild.utils.actions import Clean, Compile, MakeBuildDir
 
 
-class Empty(Experiment):
+class Empty(Experiment, entity_name='empty'):
     """The empty experiment."""
-
-    NAME = "empty"
 
     def actions_for_project(self, project):
         """ Do nothing. """
         project.compiler_extension = run.WithTimeout(
-            compiler.RunCompiler(project, self))
+            compiler.RunCompiler(project, self)
+        )
         return [MakeBuildDir(project), Compile(project), Clean(project)]
 
 
-class NoMeasurement(Experiment):
+class NoMeasurement(Experiment, entity_name='no-measurement'):
     """Run everything but do not measure anything."""
-
-    NAME = "no-measurement"
 
     def actions_for_project(self, project):
         """Execute all actions but don't do anything as extension."""
         project.compiler_extension = run.WithTimeout(
-            compiler.RunCompiler(project, self))
+            compiler.RunCompiler(project, self)
+        )
         project.runtime_extension = run.RuntimeExtension(project, self)
         return self.default_runtime_actions(project)

--- a/benchbuild/experiments/raw.py
+++ b/benchbuild/experiments/raw.py
@@ -20,7 +20,7 @@ from benchbuild.experiment import Experiment
 from benchbuild.extensions import compiler, run, time
 
 
-class RawRuntime(Experiment):
+class RawRuntime(Experiment, entity_name='raw'):
     """The polyjit experiment."""
 
     NAME = "raw"
@@ -30,7 +30,9 @@ class RawRuntime(Experiment):
         """Compile & Run the experiment with -O3 enabled."""
         project.cflags = ["-O3", "-fno-omit-frame-pointer"]
         project.runtime_extension = time.RunWithTime(
-            run.RuntimeExtension(project, self))
+            run.RuntimeExtension(project, self)
+        )
         project.compiler_extension = run.WithTimeout(
-            compiler.RunCompiler(project, self))
+            compiler.RunCompiler(project, self)
+        )
         return self.default_runtime_actions(project)

--- a/tests/e2e/test_experiment_sampling.py
+++ b/tests/e2e/test_experiment_sampling.py
@@ -26,8 +26,7 @@ class NoopExtension(Extension):
         return [run.RunInfo()]
 
 
-class SampleExperiment(bb.Experiment):
-    NAME = 'test-experiment-sampling'
+class SampleExperiment(bb.Experiment, entity_name='test-experiment-sampling'):
     CONTAINER = ContainerImage()
 
     def actions_for_project(self, project):

--- a/tests/e2e/test_git_submodules.py
+++ b/tests/e2e/test_git_submodules.py
@@ -20,8 +20,7 @@ class NoopExtension(Extension):
         return [run.RunInfo()]
 
 
-class ExperimentTest(bb.Experiment):
-    NAME = 'test-experiment'
+class ExperimentTest(bb.Experiment, entity_name='test-experiment'):
     CONTAINER = ContainerImage()
 
     def actions_for_project(self, project):

--- a/tests/test_213_error_tracking.py
+++ b/tests/test_213_error_tracking.py
@@ -52,16 +52,14 @@ class EmptyProject(prj.Project):
 
 
 @attr.s
-class ExceptionExp(experiment.Experiment):
-    NAME = "test_exception"
+class ExceptionExp(experiment.Experiment, entity_name='test_exception'):
 
     def actions_for_project(self, project):
         return [Issue213a(obj=project)]
 
 
 @attr.s
-class ErrorStateExp(experiment.Experiment):
-    NAME = "test_error_state"
+class ErrorStateExp(experiment.Experiment, entity_name='test_error_state'):
 
     def actions_for_project(self, project):
         return [Issue213b(obj=project)]


### PR DESCRIPTION
This switches from our metaclass/__new__ construct for registration and
interface checking of experiments to the newer __init_subclass__
structure.

Registration is now done by the experiment base class itself without the
need for a Metaclass.
Furthermore, the interface requirement check for a NAME is now also
removed, because we now enforce the required parameter at class
declaration time now.

All experiment subclasses require a new parameter upon declaration:
 entity_name (name is already used by metaclasses and ABC and will lead
 to collisions more easily).

This is similar to #442 