### PR TITLE
feat(environments): support custom arguments in RunProjectContainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
         pip install -r test-requirements.txt
 
     - name: Run unittests
+      env:
+        # Avoid 50 char hard-limit of podman. These are enforced because of
+        # a kernel limit of 128-chars for socket paths.
+        BB_CONTAINER_RUNROOT: "/tmp"
+        BB_CONTAINER_ROOT: "/tmp"
       run: |
         pytest --cov-config=./.coveragerc --cov=benchbuild --ignore=tests/integration benchbuild tests
         pytest --cov-config=./.coveragerc --cov=benchbuild tests/integration

--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -448,4 +448,4 @@ class BuildahImageRegistry(ImageRegistry):
         return None
 
     def _remove(self, image: model.Image) -> None:
-        pass
+        run(bb_buildah('rmi')[image.name.lower()], retcode=[0])

--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -237,7 +237,7 @@ def find_entrypoint(tag: str) -> str:
     if not config:
         raise ValueError("Could not find the container image config")
 
-    return ' '.join(config['Entrypoint'])
+    return str(config.get('Entrypoint', ''))
 
 
 class ImageRegistry(abc.ABC):

--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -190,7 +190,7 @@ class PodmanRegistry(ContainerRegistry):
                 create_cmd = create_cmd[
                     '--mount', f'type=bind,src={source},target={target}']
 
-        container_id, err = run(create_cmd['--name', name, image.name, args])
+        container_id, err = run(create_cmd['--name', name, image.name][args])
         if err:
             raise ContainerCreateError(
                 container_id, " ".join(err.argv)

--- a/benchbuild/environments/adapters/podman.py
+++ b/benchbuild/environments/adapters/podman.py
@@ -122,17 +122,21 @@ class ContainerRegistry(abc.ABC):
     def _find(self, tag: str) -> model.MaybeContainer:
         raise NotImplementedError
 
-    def create(self, image_id: str, name: str) -> model.Container:
+    def create(
+        self, image_id: str, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
         image = self.find_image(image_id)
         assert image
 
-        container = self._create(image, name)
+        container = self._create(image, name, args)
         if container is not None:
             self.containers[name] = container
         return container
 
     @abc.abstractmethod
-    def _create(self, image: model.Image, name: str) -> model.Container:
+    def _create(
+        self, image: model.Image, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
         raise NotImplementedError
 
     def start(self, container: model.Container) -> None:
@@ -163,7 +167,9 @@ error.
 
 class PodmanRegistry(ContainerRegistry):
 
-    def _create(self, image: model.Image, name: str) -> model.Container:
+    def _create(
+        self, image: model.Image, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
         mounts = [
             f'type=bind,src={mnt.source},target={mnt.target}'
             for mnt in image.mounts
@@ -184,7 +190,7 @@ class PodmanRegistry(ContainerRegistry):
                 create_cmd = create_cmd[
                     '--mount', f'type=bind,src={source},target={target}']
 
-        container_id, err = run(create_cmd['--name', name, image.name])
+        container_id, err = run(create_cmd['--name', name, image.name, args])
         if err:
             raise ContainerCreateError(
                 container_id, " ".join(err.argv)

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -1,4 +1,5 @@
 import re
+import typing as tp
 import unicodedata
 
 import attr
@@ -74,6 +75,7 @@ class RunProjectContainer(model.Command):
     name: str = attr.ib(converter=oci_compliant_name)
 
     build_dir: str = attr.ib()
+    args: tp.Sequence[str] = attr.ib(default=list)
 
 
 @attr.s(frozen=True, hash=False)

--- a/benchbuild/environments/domain/commands.py
+++ b/benchbuild/environments/domain/commands.py
@@ -75,7 +75,7 @@ class RunProjectContainer(model.Command):
     name: str = attr.ib(converter=oci_compliant_name)
 
     build_dir: str = attr.ib()
-    args: tp.Sequence[str] = attr.ib(default=list)
+    args: tp.Sequence[str] = attr.ib(default=attr.Factory(list))
 
 
 @attr.s(frozen=True, hash=False)

--- a/benchbuild/environments/service_layer/handlers.py
+++ b/benchbuild/environments/service_layer/handlers.py
@@ -79,7 +79,7 @@ def run_project_container(
             )
             LOG.warning('No result artifacts will be copied out.')
 
-        container = uow.create(cmd.image, cmd.name)
+        container = uow.create(cmd.image, cmd.name, cmd.args)
         uow.start(container)
 
 

--- a/benchbuild/environments/service_layer/unit_of_work.py
+++ b/benchbuild/environments/service_layer/unit_of_work.py
@@ -148,11 +148,15 @@ class ContainerUnitOfWork(UnitOfWork):
             while container.events:
                 yield container.events.pop(0)
 
-    def create(self, image_id: str, name: str) -> model.Container:
-        return self._create(image_id, name)
+    def create(
+        self, image_id: str, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
+        return self._create(image_id, name, args)
 
     @abc.abstractmethod
-    def _create(self, tag: str, name: str) -> model.Container:
+    def _create(
+        self, tag: str, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
         raise NotImplementedError
 
     def start(self, container: model.Container) -> None:
@@ -174,8 +178,10 @@ class PodmanContainerUOW(ContainerUnitOfWork):
     def __init__(self) -> None:
         self.registry = podman.PodmanRegistry()
 
-    def _create(self, tag: str, name: str) -> model.Container:
-        return self.registry.create(tag, name)
+    def _create(
+        self, tag: str, name: str, args: tp.Sequence[str]
+    ) -> model.Container:
+        return self.registry.create(tag, name, args)
 
     def _start(self, container: model.Container) -> None:
         self.registry.start(container)

--- a/tests/e2e/test_containers.py
+++ b/tests/e2e/test_containers.py
@@ -1,0 +1,127 @@
+import logging
+import typing as tp
+from functools import partial
+
+import pytest
+from plumbum import ProcessExecutionError
+
+from benchbuild.environments.adapters.podman import (
+    remove_container,
+    ContainerCreateError,
+)
+from benchbuild.environments.domain import declarative as decl
+from benchbuild.environments.domain import commands, events
+from benchbuild.environments.service_layer import messagebus, handlers
+from benchbuild.environments.service_layer import unit_of_work as uow
+from benchbuild.utils.cmd import cp, which
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def image_uow() -> uow.ImageUnitOfWork:
+    return uow.BuildahImageUOW()
+
+
+@pytest.fixture
+def container_uow() -> uow.ContainerUnitOfWork:
+    return uow.PodmanContainerUOW()
+
+
+@pytest.fixture
+def publish(image_uow,
+            container_uow) -> tp.Callable[[messagebus.Message], None]:
+    evt_handlers = {
+        events.LayerCreated: [],
+        events.ImageCreated: [],
+        events.ContainerCreated: [],
+        events.ContainerStartFailed: [],
+        events.ContainerStarted: [],
+        events.LayerCreationFailed: [],
+        events.DebugImageKept: [],
+        events.ImageCreationFailed: []
+    }
+
+    cmd_handlers = {
+        commands.CreateImage:
+            handlers.bootstrap(handlers.create_image, image_uow),
+        commands.CreateBenchbuildBase:
+            handlers.bootstrap(handlers.create_benchbuild_base, image_uow),
+        commands.RunProjectContainer:
+            handlers.bootstrap(handlers.run_project_container, container_uow),
+        commands.ExportImage:
+            handlers.bootstrap(handlers.export_image_handler, image_uow),
+        commands.ImportImage:
+            handlers.bootstrap(handlers.import_image_handler, image_uow),
+        commands.DeleteImage:
+            handlers.bootstrap(handlers.delete_image_handler, image_uow),
+    }
+
+    yield partial(messagebus.handle, cmd_handlers, evt_handlers)
+
+    images = list(image_uow.registry.images.values())
+    for image in images:
+        image_uow.registry.remove(image)
+
+    containers = list(container_uow.registry.containers.values())
+    for container in containers:
+        remove_container(container.container_id)
+
+
+@pytest.fixture
+def true_image() -> decl.ContainerImage:
+
+    def prepare_container() -> None:
+        true_path = which('true').strip()
+        cp(true_path, 'true')
+
+    return decl.ContainerImage() \
+        .from_('scratch') \
+        .context(prepare_container) \
+        .workingdir('/') \
+        .entrypoint('/true')
+
+
+def test_image_creation(true_image, publish, image_uow) -> None:
+    name = 'benchbuild-e2e-test_image_creation'
+
+    maybe_image = image_uow.registry.find(name)
+    assert maybe_image is None
+
+    cmd = commands.CreateImage(name, true_image)
+    publish(cmd)
+    maybe_image = image_uow.registry.find(name)
+
+    assert maybe_image is not None
+
+
+def test_image_run_no_args(true_image, publish) -> None:
+    name = 'benchbuild-e2e-test_image_run'
+
+    cmd = commands.CreateImage(name, true_image)
+    publish(cmd)
+
+    run_cmd_no_args = commands.RunProjectContainer(name, name, '/')
+    try:
+        publish(run_cmd_no_args)
+    except ContainerCreateError:
+        assert False, "RunProjectContainer was unable to create a container."
+    except ProcessExecutionError:
+        assert False, "RunProjectContainer raised an unexpected exception"
+
+
+def test_image_run_args(true_image, publish) -> None:
+    name = 'benchbuild-e2e-test_image_run'
+
+    cmd = commands.CreateImage(name, true_image)
+    publish(cmd)
+
+    run_cmd_args = commands.RunProjectContainer(
+        name, name, '/', ('arg1', 'arg2')
+    )
+    try:
+        publish(run_cmd_args)
+    except ContainerCreateError:
+        assert False, "RunProjectContainer was unable to create a container."
+    except ProcessExecutionError:
+        assert False, "RunProjectContainer raised an unexpected exception"


### PR DESCRIPTION
This adds support for custom arguments to container
entrypoints/commands.
There is no logic involved, we just hand down the supplied arguments to
the ``podman create`` command.

Interactions with ENTRYPOINTS and CMD stay the same.
Consult the Dockerfile reference for a detailed explanation on the
semantics.