### PR TITLE
Ensure a projects group is converted before storing it

### DIFF
--- a/benchbuild/utils/db.py
+++ b/benchbuild/utils/db.py
@@ -97,7 +97,7 @@ def persist_project(project):
     name = project.name
     desc = project.__doc__
     domain = str(project.domain)
-    group_name = project.group
+    group_name = str(project.group)
     version = str(project.variant)
     try:
         src_url = project.src_uri


### PR DESCRIPTION
Ensure that a projects group is converted to a string before storing it
to the database. This is useful for projects that define their group as
a `string convertable` object.