### PR TITLE
fix(actions): Fix filtering issues with SetProjectVersion 

### DIFF
--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -443,7 +443,6 @@ def discovered() -> tp.Dict[str, ProjectT]:
 
 
 def __add_single_filter__(project: ProjectT, version: str) -> ProjectT:
-
     sources = project.SOURCE
     victim = sources[0]
     victim = source.SingleVersionFilter(victim, version)

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -353,4 +353,7 @@ def context_from_revisions(revs: tp.Sequence[RevisionStr],
                 if variant.version == rev.value
             ])
 
+    if len(found) == 0:
+        raise ValueError(f'Revisions {revs} not found in any available source.')
+
     return context(*found)

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -214,7 +214,7 @@ class FetchableSource:
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def versions(self) -> tp.Iterable[Variant]:
+    def versions(self) -> tp.List[Variant]:
         """
         List all available versions of this source.
 
@@ -222,6 +222,21 @@ class FetchableSource:
             List[str]: The list of all available versions.
         """
         raise NotImplementedError()
+
+    def explore(self) -> tp.Iterable[Variant]:
+        """
+        Explore revisions of this source.
+
+        This provides access to all revisions this source can offer.
+        BenchBuild own filters will not block any revision here.
+
+        Custom sources or source filters can opt in to block revisions
+        anyways.
+
+        Returns:
+            List[str]: The list of versions to explore.
+        """
+        return self.versions()
 
     @property
     def is_expandable(self) -> bool:
@@ -334,7 +349,7 @@ def context_from_revisions(revs: tp.Sequence[RevisionStr],
     for source in sources:
         if source.is_expandable:
             found.extend([
-                variant for variant in source.versions() for rev in revs
+                variant for variant in source.explore() for rev in revs
                 if variant.version == rev.value
             ])
 

--- a/benchbuild/source/versions.py
+++ b/benchbuild/source/versions.py
@@ -77,6 +77,17 @@ class BaseVersionFilter(base.FetchableSource):
             List[str]: The list of all available versions.
         """
 
+    def explore(self) -> tp.List[base.Variant]:
+        """
+        Explore all revisions of the child source.
+
+        This bypasses the filter by default.
+
+        Returns:
+            List[str]: The list of all available versions.
+        """
+        return self.child.versions()
+
 
 class SingleVersionFilter(BaseVersionFilter):
     """

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,6 +1,9 @@
 """
 Test the actions module.
 """
+import copy
+import importlib
+import sys
 import typing as tp
 import unittest
 
@@ -9,7 +12,7 @@ from plumbum import ProcessExecutionError
 
 from benchbuild.environments.domain.declarative import ContainerImage
 from benchbuild.experiment import Experiment
-from benchbuild.project import Project
+from benchbuild.project import __add_single_filter__, Project
 from benchbuild.source import nosource, HTTP
 from benchbuild.utils import actions as a
 
@@ -60,8 +63,37 @@ class ActionsTestCase(unittest.TestCase):
         self.assertEqual(actn(), [a.StepResult.ERROR])
 
 
+class TestProject(Project):
+    NAME = '-'
+    DOMAIN = '-'
+    GROUP = '-'
+    SOURCE = [
+        HTTP(local='src-a', remote={
+            'v1a': '-',
+            'v2a': '-',
+            'v3': '-'
+        }),
+        HTTP(local='src-b', remote={
+            'v1b': '-',
+            'v2b': '-',
+            'v3': '-'
+        })
+    ]
+
+    def compile(self):
+        pass
+
+    def run_tests(self):
+        pass
+
+
+@pytest.fixture
+def t_project() -> tp.Type[Project]:
+    yield TestProject
+    importlib.reload(sys.modules[__name__])
+
+
 def describe_SetProjectVersion():
-    from benchbuild.project import __add_single_filter__, Project
     from benchbuild.source.base import RevisionStr
     from benchbuild.utils.actions import SetProjectVersion
 
@@ -71,29 +103,6 @@ def describe_SetProjectVersion():
         def actions_for_project(self,
                                 project: Project) -> tp.MutableSequence[a.Step]:
             return []
-
-    class TestProject(Project):
-        NAME = '-'
-        DOMAIN = '-'
-        GROUP = '-'
-        SOURCE = [
-            HTTP(local='src-a', remote={
-                'v1a': '-',
-                'v2a': '-',
-                'v3': '-'
-            }),
-            HTTP(local='src-b', remote={
-                'v1b': '-',
-                'v2b': '-',
-                'v3': '-'
-            })
-        ]
-
-        def compile(self):
-            pass
-
-        def run_tests(self):
-            pass
 
     def can_partially_update() -> None:
         exp = TestExperiment(projects=[TestProject])
@@ -138,8 +147,13 @@ def describe_SetProjectVersion():
         assert prj.active_variant['src-a'].version == 'v3'
         assert prj.active_variant['src-b'].version == 'v3'
 
-    def can_set_revision_through_filter() -> None:
-        project_cls = __add_single_filter__(TestProject, 'v3')
+    def can_set_revision_through_filter(t_project) -> None:
+        """
+        Check, if we can set a filtered version.
+        """
+        source_backup = copy.deepcopy(t_project.SOURCE)
+
+        project_cls = __add_single_filter__(t_project, 'v3')
         exp = TestExperiment(projects=[project_cls])
         context = exp.sample(project_cls)[0]
         prj = project_cls(variant=context)
@@ -153,3 +167,20 @@ def describe_SetProjectVersion():
 
         assert prj.active_variant['src-a'].version == 'v1a'
         assert prj.active_variant['src-b'].version == 'v1b'
+
+    def raises_error_when_no_revision_is_found() -> None:
+        """
+        Raise error, if no RevisionStr can be matched with a source.
+        """
+        exp = TestExperiment(projects=[TestProject])
+        context = exp.sample(TestProject)[0]
+        prj = TestProject(variant=context)
+
+        assert prj.active_variant['src-a'].version == 'v1a'
+        assert prj.active_variant['src-b'].version == 'v1b'
+
+        with pytest.raises(
+            ValueError,
+            match='Revisions (.+) not found in any available source.'
+        ):
+            spv = SetProjectVersion(prj, RevisionStr('does-not-exist'))

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -212,6 +212,22 @@ def test_single_versions_filter(make_source):
     assert [] == src_vs
 
 
+def test_explore_with_filter(make_source):
+    """
+    Make sure we can access revisions that would have been filtered.
+
+    Source.explore should not filter anything.
+    """
+    src_1 = make_source(range(2))
+
+    src = source.SingleVersionFilter(src_1, '0')
+    src_vs = [str(v) for v in src.versions()]
+    src_explore = [str(v) for v in src.explore()]
+
+    assert ['0'] == src_vs
+    assert ['0', '1'] == src_explore
+
+
 def test_versions_product():
     pass
 


### PR DESCRIPTION
This fixes the following problems with SetProjectVersion:

* Cannot set a project version that has been filtered by user input.
* Does not throw an error when no source could be matched to the given revision strings