### PR TITLE
feat(environments): strip container args when entering interactive mode

### DIFF
--- a/benchbuild/environments/adapters/buildah.py
+++ b/benchbuild/environments/adapters/buildah.py
@@ -237,7 +237,7 @@ def find_entrypoint(tag: str) -> str:
     if not config:
         raise ValueError("Could not find the container image config")
 
-    return str(config.get('Entrypoint', ''))
+    return str(' '.join(config.get('Entrypoint', [])))
 
 
 class ImageRegistry(abc.ABC):


### PR DESCRIPTION
This strips args passed into the container, when benchbuild enters interactive mode.
Otherwise we would pass the the given command as arguments to an interactive shell, which would break your debugging session.