### PR TITLE
Fixes double target location checkout

### DIFF
--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -3,13 +3,17 @@ Declare a git source.
 """
 import os
 import typing as tp
+import logging
+from pathlib import Path
 
 import plumbum as pb
 from plumbum.commands.base import BoundCommand
 
-from benchbuild.utils.cmd import git, ln, mkdir
+from benchbuild.utils.cmd import git, ln, mkdir, rm
 
 from . import base
+
+LOG = logging.getLogger(__name__)
 
 VarRemotes = tp.Union[str, tp.Dict[str, str]]
 Remotes = tp.Dict[str, str]
@@ -102,13 +106,19 @@ class Git(base.FetchableSource):
             if is_shallow == 'true':
                 pull('--unshallow')
 
-        mkdir('-p', tgt_loc)
-        with pb.local.cwd(tgt_loc):
-            clone(
-                '--dissociate', '--recurse-submodules', '--reference', src_loc,
-                self.remote, '.'
+        if Path(tgt_loc).exists():
+            LOG.info(
+                'Found target location %s. Going to skip creation and '
+                'repository cloning.', str(tgt_loc)
             )
-            checkout('--detach', version)
+        else:
+            mkdir('-p', tgt_loc)
+            with pb.local.cwd(tgt_loc):
+                clone(
+                    '--dissociate', '--recurse-submodules', '--reference',
+                    src_loc, self.remote, '.'
+                )
+                checkout('--detach', version)
 
         ln('-nsf', tgt_subdir, active_loc)
         return tgt_loc

--- a/benchbuild/source/git.py
+++ b/benchbuild/source/git.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import plumbum as pb
 from plumbum.commands.base import BoundCommand
 
-from benchbuild.utils.cmd import git, ln, mkdir, rm
+from benchbuild.utils.cmd import git, ln, mkdir
 
 from . import base
 


### PR DESCRIPTION
Skip the initialization of the repository should the target location
already be present.