### PR TITLE
Fixes buildah mount to install BB from source

### DIFF
--- a/benchbuild/environments/adapters/common.py
+++ b/benchbuild/environments/adapters/common.py
@@ -15,6 +15,16 @@ __MSG_SHORTER_PATH_REQUIRED = (
 )
 
 
+def buildah_version() -> tp.Tuple[int, int, int]:
+    """
+    Returns the local buildah version.
+    """
+    raw_version_string = buildah("version")
+    version_str = raw_version_string.split('\n')[0].split(":")[1].strip()
+    major, minor, patch = version_str.split('.')
+    return (int(major), int(minor), int(patch))
+
+
 def container_cmd(base: BaseCommand) -> BaseCommand:
     """
     Capture a plumbum command and apply common options.

--- a/benchbuild/environments/domain/declarative.py
+++ b/benchbuild/environments/domain/declarative.py
@@ -208,7 +208,7 @@ def add_benchbuild_layers(layers: ContainerImage) -> ContainerImage:
             'install',
             '--ignore-installed',
             tgt_dir,
-            mount=f'type=bind,src={src_dir},target={tgt_dir}',
+            mount=f'type=bind,src={src_dir},target={tgt_dir},rw',
             runtime=crun
         )
 

--- a/benchbuild/environments/domain/declarative.py
+++ b/benchbuild/environments/domain/declarative.py
@@ -17,6 +17,7 @@ import logging
 import typing as tp
 
 from benchbuild.settings import CFG
+from benchbuild.environments.adapters.common import buildah_version
 
 from . import model
 
@@ -200,6 +201,10 @@ def add_benchbuild_layers(layers: ContainerImage) -> ContainerImage:
     def from_source(image: ContainerImage) -> None:
         LOG.debug('BenchBuild will be installed from  source.')
 
+        mount = f'type=bind,src={src_dir},target={tgt_dir}'
+        if buildah_version() >= (1, 24, 0):
+            mount += ',rw'
+
         # The image requires git, pip and a working python3.7 or better.
         image.run('mkdir', f'{tgt_dir}', runtime=crun)
         image.run('pip3', 'install', 'setuptools', runtime=crun)
@@ -208,7 +213,7 @@ def add_benchbuild_layers(layers: ContainerImage) -> ContainerImage:
             'install',
             '--ignore-installed',
             tgt_dir,
-            mount=f'type=bind,src={src_dir},target={tgt_dir},rw',
+            mount=mount,
             runtime=crun
         )
 


### PR DESCRIPTION
With newer buildah versions the default for mounts becomes/is read only.
Hence, we need to specify should need to write to the mount, as in the
case with installing BB from source (this creates and writes egg files).