### PR TITLE
Fixes SingleVersionFilter version exploration

### DIFF
--- a/benchbuild/source/versions.py
+++ b/benchbuild/source/versions.py
@@ -108,3 +108,6 @@ class SingleVersionFilter(BaseVersionFilter):
         return [
             v for v in self.child.versions() if str(v) == self.filter_version
         ]
+
+    def explore(self) -> tp.List[base.Variant]:
+        return list(self.child.explore())


### PR DESCRIPTION
In the case of SingleVersionFilter we need to forward version
exploration to the child, as otherwise, we would default to the filtered
set of versions, which is restricted throught the filter.