### PR TITLE
feat(slurm): make container.runroot/container.root available for slurm customization

### DIFF
--- a/benchbuild/cli/slurm.py
+++ b/benchbuild/cli/slurm.py
@@ -75,6 +75,11 @@ class Slurm(cli.Application):
         )
 
         CFG["build_dir"] = str(CFG["slurm"]["node_dir"])
+        if CFG["slurm"]["container_root"].value is not None:
+            CFG["container"]["root"] = CFG["slurm"]["container_root"].value
+        if CFG["slurm"]["container_runroot"].value is not None:
+            CFG["container"]["runroot"] = CFG["slurm"]["container_runroot"
+                                                      ].value
 
         if not wanted_experiments:
             print("Could not find any experiment. Exiting.")

--- a/benchbuild/settings.py
+++ b/benchbuild/settings.py
@@ -260,6 +260,14 @@ CFG["slurm"] = {
     "extra_log": {
         "desc": "Extra log file to be managed by SLURM",
         "default": "/tmp/.slurm"
+    },
+    "container_root": {
+        "default": None,
+        "desc": "Permanent storage for container images"
+    },
+    "container_runroot": {
+        "default": None,
+        "desc": "Runtime storage for containers"
     }
 }
 


### PR DESCRIPTION
This provides 2 custom variables for SLURM script generation.

CONTAINER_RUN -> SLURM_CONTAINER_RUN
CONTAINER_RUNROOT -> SLURM_CONTAINER_RUNROOT

Fixes #528