### PR TITLE
add source to download multiple files via HTTP

### DIFF
--- a/benchbuild/source/__init__.py
+++ b/benchbuild/source/__init__.py
@@ -21,6 +21,7 @@ from .base import to_str as to_str
 from .git import Git as Git
 from .git import GitSubmodule as GitSubmodule
 from .http import HTTP as HTTP
+from .http import HTTPMultiple as HTTPMultiple
 from .http import HTTPUntar as HTTPUntar
 from .versions import BaseVersionFilter as BaseVersionFilter
 from .versions import SingleVersionFilter as SingleVersionFilter

--- a/benchbuild/source/http.py
+++ b/benchbuild/source/http.py
@@ -109,6 +109,36 @@ class HTTPUntar(HTTP):
         return target_path
 
 
+class HTTPMultiple(HTTP):
+    """
+    Fetch and download multiple files via HTTP.
+    """
+
+    def __init__(
+        self,
+        local: str,
+        remote: tp.Union[str, tp.Dict[str, str]],
+        files: tp.List[str]
+    ):
+        super().__init__(local, remote)
+        self._files = files
+
+    def fetch_version(self, version: str) -> pb.LocalPath:
+        prefix = base.target_prefix()
+        remotes = normalize_remotes(self.remote)
+
+        url = remotes[version]
+        target_name = versioned_target_name(self.local, version)
+
+        cache_path = pb.local.path(prefix) / target_name
+        mkdir('-p', cache_path)
+
+        for file in self._files:
+            download_single_version(f'{url}/{file}', cache_path / file)
+
+        return cache_path
+
+
 def normalize_remotes(remote: VarRemotes) -> Remotes:
     if isinstance(remote, str):
         raise TypeError('\'remote\' needs to be a mapping type')


### PR DESCRIPTION
Hi, for some experiments in https://github.com/se-sic/VaRA-Tool-Suite, we need to download multiple files over HTTP. This is currently a bit cumbersome as it requires us to specify multiple HTTP sources. @vulder had the idea to implement a source class that allows you to specify the url and then the files you want to download, like so:
```python
class HTTPMultiple(
    local="geo-maps",
    remote={
        "1.0":
            "https://github.com/simonepri/geo-maps/releases/"
            "download/v0.6.0/"
    }
    files = ["countries-land-1km.geo.json", ...]
)
```

Let me know, what you think.