### PR TITLE
Change variants separator

### DIFF
--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -538,7 +538,7 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
 
     def csv(in_str: tp.Union[tp.Any, str]) -> bool:
         if isinstance(in_str, str):
-            return len(in_str.split(",")) > 1
+            return len(in_str.split("*")) > 1
         return False
 
     is_csv = csv(version_in)
@@ -548,7 +548,7 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
         return __add_single_filter__(project, str(version_in))
 
     if isinstance(version_in, list) or is_csv:
-        version_in = version_in.split(",") if is_csv else version_in
+        version_in = version_in.split("*") if is_csv else version_in
         return __add_indexed_filters__(project, version_in)
 
     if isinstance(version_in, dict):

--- a/benchbuild/project.py
+++ b/benchbuild/project.py
@@ -538,7 +538,7 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
 
     def csv(in_str: tp.Union[tp.Any, str]) -> bool:
         if isinstance(in_str, str):
-            return len(in_str.split("*")) > 1
+            return len(in_str.split("+")) > 1
         return False
 
     is_csv = csv(version_in)
@@ -548,7 +548,7 @@ def __add_filters__(project: ProjectT, version_str: str) -> ProjectT:
         return __add_single_filter__(project, str(version_in))
 
     if isinstance(version_in, list) or is_csv:
-        version_in = version_in.split("*") if is_csv else version_in
+        version_in = version_in.split("+") if is_csv else version_in
         return __add_indexed_filters__(project, version_in)
 
     if isinstance(version_in, dict):

--- a/benchbuild/source/base.py
+++ b/benchbuild/source/base.py
@@ -175,7 +175,7 @@ def to_str(*variants: Variant) -> str:
     Returns:
         string representation of all input variants joined by ','.
     """
-    return ",".join([str(i) for i in variants])
+    return "*".join([str(i) for i in variants])
 
 
 class Fetchable(Protocol):


### PR DESCRIPTION
Currently benchbuild uses a comma (`,`) to join multiple variants into a string. This can cause issues during compilation of some C/CPP projects when they set linker options.

The specific issue arises when using `-Wl,rpath,<Path>` to pass an rpath to the linker. As benchbuild automatically creates a new build folder for the project for compilation, the Path can contain commas if the project uses variants. 

However, `-Wl` treats every comma as a separator for inputs to pass on to the linker. The result is a compilation error.

I think it would be a reasonable change to switch to a different separator. For now, I use the asterisk in my setup but maybe another separator is better suited (asterisks in names causes some weird behavior with with auto-completion in the command line)